### PR TITLE
fix: Prevent duplicate folder creation when AI omits root segment

### DIFF
--- a/src/services/bookmarks.ts
+++ b/src/services/bookmarks.ts
@@ -99,6 +99,17 @@ export const createFolderPath = async (
       continue;
     }
 
+    // AI sometimes omits root segments (e.g. "Utilities" instead of "Bookmarks Bar/Utilities")
+    const suffixMatch = Object.entries(pathToIdMap).find(
+      ([key]) => key.endsWith(`/${resolvedPath}`)
+    );
+
+    if (suffixMatch) {
+      currentParentId = suffixMatch[1];
+      resolvedPath = suffixMatch[0];
+      continue;
+    }
+
     const newFolder = await createFolder(currentParentId, segment);
     currentParentId = newFolder.id;
     pathToIdMap[resolvedPath] = newFolder.id;


### PR DESCRIPTION
## Summary
- **Bug**: When the AI suggests a new subfolder (e.g. `NEW: Utilities/Finance`), accepting it sometimes created a **duplicate** "Utilities" folder instead of reusing the existing one
- **Cause**: `createFolderPath` does a direct lookup in `pathToIdMap`, but the map keys include the full Chrome root path (e.g. `Bookmarks Bar/Utilities`). When the AI omits the root segment and returns just `Utilities/Finance`, the lookup fails and a new folder is blindly created
- **Fix**: Added a suffix-match fallback — when the direct lookup misses, it searches for any existing path ending with `/<segment>`, reusing the existing folder instead of creating a duplicate

## Test plan
- [ ] Have an existing folder like "Utilities" in your bookmarks
- [ ] Trigger AI organize on a page that fits that folder
- [ ] If AI suggests a new subfolder (e.g. "Utilities/Finance"), accept it
- [ ] Verify "Finance" is created **inside** the existing "Utilities" — no duplicate "Utilities" folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)