### PR TITLE
fix: Resolve duplicate folders when AI omits root path segments

### DIFF
--- a/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
+++ b/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
@@ -100,6 +100,8 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
 
     try {
       setIsOrganizing(true);
+      setExistingBookmarkPath(null);
+      setPendingSuggestion(null);
       startLoadingMessages();
 
       const folderData = await getFolderDataForAI();

--- a/src/services/bookmarks.ts
+++ b/src/services/bookmarks.ts
@@ -99,6 +99,17 @@ export const createFolderPath = async (
       continue;
     }
 
+    // AI sometimes omits root segments (e.g. "Utilities" instead of "Bookmarks Bar/Utilities")
+    const suffixMatch = Object.entries(pathToIdMap).find(
+      ([key]) => key.endsWith(`/${resolvedPath}`)
+    );
+
+    if (suffixMatch) {
+      currentParentId = suffixMatch[1];
+      resolvedPath = suffixMatch[0];
+      continue;
+    }
+
     const newFolder = await createFolder(currentParentId, segment);
     currentParentId = newFolder.id;
     pathToIdMap[resolvedPath] = newFolder.id;

--- a/src/services/bookmarks.ts
+++ b/src/services/bookmarks.ts
@@ -100,13 +100,14 @@ export const createFolderPath = async (
     }
 
     // AI sometimes omits root segments (e.g. "Utilities" instead of "Bookmarks Bar/Utilities")
-    const suffixMatch = Object.entries(pathToIdMap).find(
+    // Only resolve when the match is unambiguous — avoids misfiling when multiple folders share a name
+    const suffixMatches = Object.entries(pathToIdMap).filter(
       ([key]) => key.endsWith(`/${resolvedPath}`)
     );
 
-    if (suffixMatch) {
-      currentParentId = suffixMatch[1];
-      resolvedPath = suffixMatch[0];
+    if (suffixMatches.length === 1) {
+      currentParentId = suffixMatches[0][1];
+      resolvedPath = suffixMatches[0][0];
       continue;
     }
 


### PR DESCRIPTION
## Summary
- AI sometimes returns truncated folder paths (e.g. `Utilities` instead of `Bookmarks Bar/Utilities`)
- Added **suffix matching** in `createFolderPath` to detect when an existing folder matches the AI's shortened path
- Prevents duplicate folder creation by reusing the existing folder instead

## Test plan
- [ ] Organize a bookmark where AI returns a path without root prefix (e.g. just `Utilities`)
- [ ] Verify the bookmark is placed in the existing `Bookmarks Bar/Utilities` folder
- [ ] Verify no duplicate folders are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)