### PR TITLE
feat: Blog tab with Contentful API integration

### DIFF
--- a/src/components/icons/Icons.tsx
+++ b/src/components/icons/Icons.tsx
@@ -307,6 +307,40 @@ export const ChevronDownIcon = ({ width = 14, height = 14 }: IconProps) => (
   </svg>
 );
 
+export const ChevronLeftIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    width={width}
+    height={height}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M15 19l-7-7 7-7"
+    />
+  </svg>
+);
+
+export const ChevronRightIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    width={width}
+    height={height}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M9 5l7 7-7 7"
+    />
+  </svg>
+);
+
 export const RefreshIcon = ({ width = 14, height = 14 }: IconProps) => (
   <svg
     fill="none"

--- a/src/components/icons/Icons.tsx
+++ b/src/components/icons/Icons.tsx
@@ -442,3 +442,20 @@ export const FolderIcon = ({ width = 14, height = 14 }: IconProps) => (
     />
   </svg>
 );
+
+export const ExternalLinkIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    width={width}
+    height={height}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"
+    />
+  </svg>
+);

--- a/src/components/tabs/BlogTab.css
+++ b/src/components/tabs/BlogTab.css
@@ -1,0 +1,67 @@
+/* ========================================
+   Blog Tab
+   ======================================== */
+.blog-tab {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xl);
+}
+
+.blog-tab-description {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-normal);
+}
+
+/* ========================================
+   Blog Post List
+   ======================================== */
+.blog-tab-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+/* ========================================
+   Visit Blog Button
+   ======================================== */
+.blog-tab-visit-button {
+  align-self: center;
+}
+
+/* ========================================
+   Loading State
+   ======================================== */
+.blog-tab-loading {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  color: var(--color-text-muted);
+}
+
+.blog-tab-loading-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-light);
+  font-weight: var(--font-weight-medium);
+}
+
+/* ========================================
+   Empty / Error State
+   ======================================== */
+.blog-tab-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xl);
+}
+
+.blog-tab-empty-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-light);
+  font-weight: var(--font-weight-medium);
+}

--- a/src/components/tabs/BlogTab.css
+++ b/src/components/tabs/BlogTab.css
@@ -14,6 +14,56 @@
 }
 
 /* ========================================
+   Tag Filter Row (arrows + scrollable pills)
+   ======================================== */
+.blog-tab-filters-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.blog-tab-filters-arrow {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+}
+
+.blog-tab-filters {
+  display: flex;
+  gap: var(--spacing-sm);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.blog-tab-filters::-webkit-scrollbar {
+  display: none;
+}
+
+.blog-tab-filter-pill {
+  flex-shrink: 0;
+  padding: var(--spacing-xs) var(--spacing-xl);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-medium);
+  font-family: var(--font-family);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: background-color var(--transition-smooth), border-color var(--transition-smooth), color var(--transition-smooth);
+}
+
+.blog-tab-filter-pill:hover {
+  background-color: var(--color-surface);
+}
+
+.blog-tab-filter-pill.active {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-white);
+}
+
+/* ========================================
    Blog Post List
    ======================================== */
 .blog-tab-list {

--- a/src/components/tabs/BlogTab.tsx
+++ b/src/components/tabs/BlogTab.tsx
@@ -1,7 +1,87 @@
-const BlogTab = () => (
-  <div className="tab-placeholder">
-    <p className="tab-placeholder-text">Blog coming soon</p>
-  </div>
-);
+import { useState, useEffect, useCallback } from 'react';
+import { SpinnerIcon, ExternalLinkIcon } from '../icons/Icons';
+import Button from '../Button/Button';
+import BlogCard from './blog/BlogCard';
+import { fetchBlogPosts } from '../../services/blog';
+import { type BlogPost } from '../../types/discover';
+import './BlogTab.css';
+
+const MARKMIND_BLOG_URL = 'https://markmind.xyz/blog';
+
+const BlogTab = () => {
+  const [blogPosts, setBlogPosts] = useState<BlogPost[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  const loadBlogPosts = useCallback(async () => {
+    setIsLoading(true);
+    setHasError(false);
+
+    try {
+      const posts = await fetchBlogPosts();
+      setBlogPosts(posts);
+    } catch (error) {
+      console.error('Failed to load blog posts:', error);
+      setHasError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadBlogPosts();
+  }, [loadBlogPosts]);
+
+  const handleVisitBlog = useCallback(() => {
+    chrome.tabs.create({ url: MARKMIND_BLOG_URL });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="blog-tab-loading">
+        <SpinnerIcon width={18} height={18} />
+        <p className="blog-tab-loading-text">Loading articles...</p>
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div className="blog-tab-empty">
+        <p className="blog-tab-empty-text">Could not load articles right now.</p>
+        <Button variant="ghost" onClick={loadBlogPosts}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (blogPosts.length === 0) {
+    return (
+      <div className="blog-tab-empty">
+        <p className="blog-tab-empty-text">No articles yet. Check back soon!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="blog-tab">
+      <p className="blog-tab-description">
+        Stories, tips, and deep dives into organizing your digital life.
+      </p>
+
+      <div className="blog-tab-list">
+        {blogPosts.map((post) => (
+          <BlogCard key={post.slug} post={post} />
+        ))}
+      </div>
+
+      <Button variant="ghost" onClick={handleVisitBlog} className="blog-tab-visit-button">
+        Visit our blog
+        <ExternalLinkIcon width={10} height={10} />
+      </Button>
+    </div>
+  );
+};
 
 export default BlogTab;

--- a/src/components/tabs/BlogTab.tsx
+++ b/src/components/tabs/BlogTab.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { SpinnerIcon, ExternalLinkIcon } from '../icons/Icons';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { SpinnerIcon, ExternalLinkIcon, ChevronLeftIcon, ChevronRightIcon } from '../icons/Icons';
 import Button from '../Button/Button';
 import BlogCard from './blog/BlogCard';
 import { fetchBlogPosts } from '../../services/blog';
@@ -7,11 +7,17 @@ import { type BlogPost } from '../../types/discover';
 import './BlogTab.css';
 
 const MARKMIND_BLOG_URL = 'https://markmind.xyz/blog';
+const ALL_FILTER = 'All';
+const SCROLL_AMOUNT = 120;
 
 const BlogTab = () => {
   const [blogPosts, setBlogPosts] = useState<BlogPost[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
+  const [activeTag, setActiveTag] = useState(ALL_FILTER);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const filtersRef = useRef<HTMLDivElement>(null);
 
   const loadBlogPosts = useCallback(async () => {
     setIsLoading(true);
@@ -31,6 +37,43 @@ const BlogTab = () => {
   useEffect(() => {
     loadBlogPosts();
   }, [loadBlogPosts]);
+
+  const categories = useMemo(() => {
+    const categorySet = new Set<string>();
+    blogPosts.forEach((post) => {
+      const primaryTag = post.tags[0];
+      if (primaryTag) categorySet.add(primaryTag);
+    });
+    return [ALL_FILTER, ...Array.from(categorySet).sort()];
+  }, [blogPosts]);
+
+  const filteredPosts = useMemo(() => {
+    if (activeTag === ALL_FILTER) return blogPosts;
+    return blogPosts.filter((post) => post.tags[0] === activeTag);
+  }, [blogPosts, activeTag]);
+
+  const updateScrollArrows = useCallback(() => {
+    const container = filtersRef.current;
+    if (!container) return;
+    setCanScrollLeft(container.scrollLeft > 0);
+    setCanScrollRight(container.scrollLeft + container.clientWidth < container.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    updateScrollArrows();
+  }, [categories, updateScrollArrows]);
+
+  const handleScrollLeft = useCallback(() => {
+    filtersRef.current?.scrollBy({ left: -SCROLL_AMOUNT, behavior: 'smooth' });
+  }, []);
+
+  const handleScrollRight = useCallback(() => {
+    filtersRef.current?.scrollBy({ left: SCROLL_AMOUNT, behavior: 'smooth' });
+  }, []);
+
+  const handleTagSelect = useCallback((tag: string) => {
+    setActiveTag(tag);
+  }, []);
 
   const handleVisitBlog = useCallback(() => {
     chrome.tabs.create({ url: MARKMIND_BLOG_URL });
@@ -70,8 +113,35 @@ const BlogTab = () => {
         Stories, tips, and deep dives into organizing your digital life.
       </p>
 
+      {categories.length > 2 && (
+        <div className="blog-tab-filters-row">
+          {canScrollLeft && (
+            <Button variant="icon" className="blog-tab-filters-arrow left" onClick={handleScrollLeft} title="Scroll left">
+              <ChevronLeftIcon width={12} height={12} />
+            </Button>
+          )}
+          <div className="blog-tab-filters" ref={filtersRef} onScroll={updateScrollArrows}>
+            {categories.map((tag) => (
+              <Button
+                key={tag}
+                variant="unstyled"
+                className={`blog-tab-filter-pill${activeTag === tag ? ' active' : ''}`}
+                onClick={() => handleTagSelect(tag)}
+              >
+                {tag}
+              </Button>
+            ))}
+          </div>
+          {canScrollRight && (
+            <Button variant="icon" className="blog-tab-filters-arrow right" onClick={handleScrollRight} title="Scroll right">
+              <ChevronRightIcon width={12} height={12} />
+            </Button>
+          )}
+        </div>
+      )}
+
       <div className="blog-tab-list">
-        {blogPosts.map((post) => (
+        {filteredPosts.map((post) => (
           <BlogCard key={post.slug} post={post} />
         ))}
       </div>

--- a/src/components/tabs/blog/BlogCard.css
+++ b/src/components/tabs/blog/BlogCard.css
@@ -1,0 +1,97 @@
+/* ========================================
+   Blog Card (article preview with image)
+   ======================================== */
+.blog-card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  cursor: pointer;
+  transition: transform var(--transition-fast), background-color var(--transition-smooth);
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+}
+
+.blog-card:hover {
+  border-color: var(--color-primary);
+  background-color: var(--color-surface);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+/* ========================================
+   Image Banner
+   ======================================== */
+.blog-card-image {
+  width: 100%;
+  height: 120px;
+  overflow: hidden;
+  background-color: var(--color-surface);
+}
+
+.blog-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ========================================
+   Content
+   ======================================== */
+.blog-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xl) var(--spacing-2xl) var(--spacing-2xl);
+}
+
+/* ========================================
+   Meta Row (badge + reading time + icon)
+   ======================================== */
+.blog-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.blog-card-badge {
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--spacing-2xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-accent-purple-bg);
+  color: var(--color-accent-purple);
+}
+
+.blog-card-reading-time {
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-light);
+}
+
+/* ========================================
+   Text
+   ======================================== */
+.blog-card-title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  line-height: var(--line-height-tight);
+}
+
+.blog-card-excerpt {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.blog-card-date {
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-light);
+  margin-top: var(--spacing-2xs);
+}

--- a/src/components/tabs/blog/BlogCard.css
+++ b/src/components/tabs/blog/BlogCard.css
@@ -1,12 +1,13 @@
 /* ========================================
-   Blog Card (article preview with image)
+   Blog Card (horizontal: image left, content right)
    ======================================== */
 .blog-card {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: stretch;
   background-color: var(--color-white);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: transform var(--transition-fast), background-color var(--transition-smooth);
   text-decoration: none;
@@ -17,16 +18,17 @@
 .blog-card:hover {
   border-color: var(--color-primary);
   background-color: var(--color-surface);
-  transform: translateY(-2px);
+  transform: translateY(-1px);
   text-decoration: none;
 }
 
 /* ========================================
-   Image Banner
+   Thumbnail (left side)
    ======================================== */
 .blog-card-image {
-  width: 100%;
-  height: 120px;
+  width: 96px;
+  min-height: 80px;
+  flex-shrink: 0;
   overflow: hidden;
   background-color: var(--color-surface);
 }
@@ -38,13 +40,16 @@
 }
 
 /* ========================================
-   Content
+   Content (right side)
    ======================================== */
 .blog-card-content {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-xs);
-  padding: var(--spacing-xl) var(--spacing-2xl) var(--spacing-2xl);
+  justify-content: center;
+  gap: var(--spacing-2xs);
+  padding: var(--spacing-md) var(--spacing-xl);
+  min-width: 0;
+  flex: 1;
 }
 
 /* ========================================
@@ -53,13 +58,13 @@
 .blog-card-meta {
   display: flex;
   align-items: center;
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
 }
 
 .blog-card-badge {
   font-size: var(--font-size-2xs);
   font-weight: var(--font-weight-semibold);
-  padding: var(--spacing-2xs) var(--spacing-sm);
+  padding: var(--spacing-2xs) var(--spacing-xs);
   border-radius: var(--radius-sm);
   background-color: var(--color-accent-purple-bg);
   color: var(--color-accent-purple);
@@ -74,14 +79,18 @@
    Text
    ======================================== */
 .blog-card-title {
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text);
   line-height: var(--line-height-tight);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .blog-card-excerpt {
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-2xs);
   color: var(--color-text-secondary);
   line-height: var(--line-height-normal);
   display: -webkit-box;
@@ -93,5 +102,4 @@
 .blog-card-date {
   font-size: var(--font-size-2xs);
   color: var(--color-text-light);
-  margin-top: var(--spacing-2xs);
 }

--- a/src/components/tabs/blog/BlogCard.tsx
+++ b/src/components/tabs/blog/BlogCard.tsx
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { ExternalLinkIcon } from '../../icons/Icons';
+import { type BlogPost } from '../../../types/discover';
+import './BlogCard.css';
+
+interface BlogCardProps {
+  post: BlogPost;
+}
+
+const formatDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
+};
+
+const BlogCard = ({ post }: BlogCardProps) => {
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      chrome.tabs.create({ url: post.url });
+    },
+    [post.url]
+  );
+
+  const primaryTag = post.tags[0] ?? 'Article';
+
+  return (
+    <a
+      href={post.url}
+      className="blog-card"
+      onClick={handleClick}
+      title={`Read: ${post.title}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {post.image && (
+        <div className="blog-card-image">
+          <img src={post.image} alt={post.title} />
+        </div>
+      )}
+      <div className="blog-card-content">
+        <div className="blog-card-meta">
+          <span className="blog-card-badge">{primaryTag}</span>
+          <span className="blog-card-reading-time">{post.readingTime}</span>
+          <ExternalLinkIcon width={10} height={10} />
+        </div>
+        <h3 className="blog-card-title">{post.title}</h3>
+        <p className="blog-card-excerpt">{post.excerpt}</p>
+        <span className="blog-card-date">{formatDate(post.datePublished)}</span>
+      </div>
+    </a>
+  );
+};
+
+export default BlogCard;

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -1,7 +1,7 @@
 import { type BlogPost } from '../types/discover';
 
 const CONTENTFUL_SPACE_ID = 'tgx6mb7o35jr';
-const CONTENTFUL_ACCESS_TOKEN = '8JT2A7uy2EjuM8E6gCjYLOZrsPLyhNq1wkP0vJxKqAk';
+const CONTENTFUL_ACCESS_TOKEN = '3huNM1SVvgOfd1S1V7y9H2w_00i2UmfPDFwAJ2oQzU8';
 const CONTENTFUL_CDN_URL = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/entries`;
 const CONTENT_TYPE = 'blogPost';
 

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -1,14 +1,65 @@
 import { type BlogPost } from '../types/discover';
 
-const BLOG_API_URL = 'https://markmind.xyz/api/blog';
+const CONTENTFUL_SPACE_ID = 'tgx6mb7o35jr';
+const CONTENTFUL_ACCESS_TOKEN = '8JT2A7uy2EjuM8E6gCjYLOZrsPLyhNq1wkP0vJxKqAk';
+const CONTENTFUL_CDN_URL = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/entries`;
+const CONTENT_TYPE = 'blogPost';
 
 const CACHE_KEY = 'blogPostsCache';
 const CACHE_TTL_MS = 60 * 60 * 1000;
+
+const BLOG_BASE_URL = 'https://markmind.xyz/blog';
 
 interface BlogCache {
   posts: BlogPost[];
   fetchedAt: number;
 }
+
+interface ContentfulAsset {
+  sys: { id: string };
+  fields: { file: { url: string } };
+}
+
+interface ContentfulEntry {
+  fields: {
+    title: string;
+    slug: string;
+    excerpt: string;
+    tags: string[];
+    datePublished: string;
+    readingTime: string;
+    author: string;
+    image?: { sys: { id: string } };
+  };
+}
+
+interface ContentfulResponse {
+  items: ContentfulEntry[];
+  includes?: { Asset?: ContentfulAsset[] };
+}
+
+const resolveImageUrl = (
+  imageLink: { sys: { id: string } } | undefined,
+  assets: ContentfulAsset[]
+): string => {
+  if (!imageLink) return '';
+  const asset = assets.find((assetItem) => assetItem.sys.id === imageLink.sys.id);
+  const url = asset?.fields?.file?.url;
+  if (!url) return '';
+  return url.startsWith('//') ? `https:${url}` : url;
+};
+
+const mapEntryToBlogPost = (entry: ContentfulEntry, assets: ContentfulAsset[]): BlogPost => ({
+  title: entry.fields.title,
+  slug: entry.fields.slug,
+  url: `${BLOG_BASE_URL}/${entry.fields.slug}`,
+  excerpt: entry.fields.excerpt,
+  image: resolveImageUrl(entry.fields.image, assets),
+  tags: entry.fields.tags ?? [],
+  datePublished: entry.fields.datePublished,
+  readingTime: entry.fields.readingTime,
+  author: entry.fields.author,
+});
 
 const getCachedBlogData = async (): Promise<BlogCache | null> => {
   try {
@@ -36,20 +87,29 @@ export const fetchBlogPosts = async (): Promise<BlogPost[]> => {
   if (isFresh) return cachedBlogData.posts;
 
   try {
-    const response = await fetch(BLOG_API_URL);
+    const params = new URLSearchParams({
+      access_token: CONTENTFUL_ACCESS_TOKEN,
+      content_type: CONTENT_TYPE,
+      order: '-fields.datePublished',
+      limit: '100',
+      include: '1',
+    });
+
+    const response = await fetch(`${CONTENTFUL_CDN_URL}?${params}`);
 
     if (!response.ok) {
-      throw new Error(`Blog API returned ${response.status}`);
+      throw new Error(`Contentful API returned ${response.status}`);
     }
 
-    const data = await response.json();
-    const posts: BlogPost[] = data.posts ?? [];
+    const data: ContentfulResponse = await response.json();
+    const assets = data.includes?.Asset ?? [];
+    const posts = data.items.map((entry) => mapEntryToBlogPost(entry, assets));
 
     await setCachedPosts(posts);
 
     return posts;
   } catch (error) {
-    console.error('Failed to fetch blog posts:', error);
+    console.error('Failed to fetch blog posts from Contentful:', error);
 
     if (cachedBlogData?.posts) return cachedBlogData.posts;
 

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -1,65 +1,14 @@
 import { type BlogPost } from '../types/discover';
 
-const CONTENTFUL_SPACE_ID = 'tgx6mb7o35jr';
-const CONTENTFUL_ACCESS_TOKEN = '8JT2A7uy2EjuM8E6gCjYLOZrsPLyhNq1wkP0vJxKqAk';
-const CONTENTFUL_CDN_URL = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/entries`;
-const CONTENT_TYPE = 'blogPost';
+const BLOG_API_URL = 'https://markmind.xyz/api/blog';
 
 const CACHE_KEY = 'blogPostsCache';
 const CACHE_TTL_MS = 60 * 60 * 1000;
-
-const BLOG_BASE_URL = 'https://markmind.xyz/blog';
 
 interface BlogCache {
   posts: BlogPost[];
   fetchedAt: number;
 }
-
-interface ContentfulAsset {
-  sys: { id: string };
-  fields: { file: { url: string } };
-}
-
-interface ContentfulEntry {
-  fields: {
-    title: string;
-    slug: string;
-    excerpt: string;
-    tags: string[];
-    datePublished: string;
-    readingTime: string;
-    author: string;
-    image?: { sys: { id: string } };
-  };
-}
-
-interface ContentfulResponse {
-  items: ContentfulEntry[];
-  includes?: { Asset?: ContentfulAsset[] };
-}
-
-const resolveImageUrl = (
-  imageLink: { sys: { id: string } } | undefined,
-  assets: ContentfulAsset[]
-): string => {
-  if (!imageLink) return '';
-  const asset = assets.find((assetItem) => assetItem.sys.id === imageLink.sys.id);
-  const url = asset?.fields?.file?.url;
-  if (!url) return '';
-  return url.startsWith('//') ? `https:${url}` : url;
-};
-
-const mapEntryToBlogPost = (entry: ContentfulEntry, assets: ContentfulAsset[]): BlogPost => ({
-  title: entry.fields.title,
-  slug: entry.fields.slug,
-  url: `${BLOG_BASE_URL}/${entry.fields.slug}`,
-  excerpt: entry.fields.excerpt,
-  image: resolveImageUrl(entry.fields.image, assets),
-  tags: entry.fields.tags ?? [],
-  datePublished: entry.fields.datePublished,
-  readingTime: entry.fields.readingTime,
-  author: entry.fields.author,
-});
 
 const getCachedBlogData = async (): Promise<BlogCache | null> => {
   try {
@@ -87,29 +36,20 @@ export const fetchBlogPosts = async (): Promise<BlogPost[]> => {
   if (isFresh) return cachedBlogData.posts;
 
   try {
-    const params = new URLSearchParams({
-      access_token: CONTENTFUL_ACCESS_TOKEN,
-      content_type: CONTENT_TYPE,
-      order: '-fields.datePublished',
-      limit: '100',
-      include: '1',
-    });
-
-    const response = await fetch(`${CONTENTFUL_CDN_URL}?${params}`);
+    const response = await fetch(BLOG_API_URL);
 
     if (!response.ok) {
-      throw new Error(`Contentful API returned ${response.status}`);
+      throw new Error(`Blog API returned ${response.status}`);
     }
 
-    const data: ContentfulResponse = await response.json();
-    const assets = data.includes?.Asset ?? [];
-    const posts = data.items.map((entry) => mapEntryToBlogPost(entry, assets));
+    const data = await response.json();
+    const posts: BlogPost[] = data.posts ?? [];
 
     await setCachedPosts(posts);
 
     return posts;
   } catch (error) {
-    console.error('Failed to fetch blog posts from Contentful:', error);
+    console.error('Failed to fetch blog posts:', error);
 
     if (cachedBlogData?.posts) return cachedBlogData.posts;
 

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -1,0 +1,118 @@
+import { type BlogPost } from '../types/discover';
+
+const CONTENTFUL_SPACE_ID = 'tgx6mb7o35jr';
+const CONTENTFUL_ACCESS_TOKEN = '8JT2A7uy2EjuM8E6gCjYLOZrsPLyhNq1wkP0vJxKqAk';
+const CONTENTFUL_CDN_URL = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/entries`;
+const CONTENT_TYPE = 'blogPost';
+
+const CACHE_KEY = 'blogPostsCache';
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+const BLOG_BASE_URL = 'https://markmind.xyz/blog';
+
+interface BlogCache {
+  posts: BlogPost[];
+  fetchedAt: number;
+}
+
+interface ContentfulAsset {
+  sys: { id: string };
+  fields: { file: { url: string } };
+}
+
+interface ContentfulEntry {
+  fields: {
+    title: string;
+    slug: string;
+    excerpt: string;
+    tags: string[];
+    datePublished: string;
+    readingTime: string;
+    author: string;
+    image?: { sys: { id: string } };
+  };
+}
+
+interface ContentfulResponse {
+  items: ContentfulEntry[];
+  includes?: { Asset?: ContentfulAsset[] };
+}
+
+const resolveImageUrl = (
+  imageLink: { sys: { id: string } } | undefined,
+  assets: ContentfulAsset[]
+): string => {
+  if (!imageLink) return '';
+  const asset = assets.find((assetItem) => assetItem.sys.id === imageLink.sys.id);
+  const url = asset?.fields?.file?.url;
+  if (!url) return '';
+  return url.startsWith('//') ? `https:${url}` : url;
+};
+
+const mapEntryToBlogPost = (entry: ContentfulEntry, assets: ContentfulAsset[]): BlogPost => ({
+  title: entry.fields.title,
+  slug: entry.fields.slug,
+  url: `${BLOG_BASE_URL}/${entry.fields.slug}`,
+  excerpt: entry.fields.excerpt,
+  image: resolveImageUrl(entry.fields.image, assets),
+  tags: entry.fields.tags ?? [],
+  datePublished: entry.fields.datePublished,
+  readingTime: entry.fields.readingTime,
+  author: entry.fields.author,
+});
+
+const getCachedBlogData = async (): Promise<BlogCache | null> => {
+  try {
+    const result = await chrome.storage.local.get(CACHE_KEY);
+    return (result[CACHE_KEY] as BlogCache | undefined) ?? null;
+  } catch (error) {
+    console.error('Failed to read blog cache:', error);
+    return null;
+  }
+};
+
+const setCachedPosts = async (posts: BlogPost[]): Promise<void> => {
+  try {
+    const cache: BlogCache = { posts, fetchedAt: Date.now() };
+    await chrome.storage.local.set({ [CACHE_KEY]: cache });
+  } catch (error) {
+    console.error('Failed to write blog cache:', error);
+  }
+};
+
+export const fetchBlogPosts = async (): Promise<BlogPost[]> => {
+  const cachedBlogData = await getCachedBlogData();
+
+  const isFresh = cachedBlogData && Date.now() - cachedBlogData.fetchedAt < CACHE_TTL_MS;
+  if (isFresh) return cachedBlogData.posts;
+
+  try {
+    const params = new URLSearchParams({
+      access_token: CONTENTFUL_ACCESS_TOKEN,
+      content_type: CONTENT_TYPE,
+      order: '-fields.datePublished',
+      limit: '100',
+      include: '1',
+    });
+
+    const response = await fetch(`${CONTENTFUL_CDN_URL}?${params}`);
+
+    if (!response.ok) {
+      throw new Error(`Contentful API returned ${response.status}`);
+    }
+
+    const data: ContentfulResponse = await response.json();
+    const assets = data.includes?.Asset ?? [];
+    const posts = data.items.map((entry) => mapEntryToBlogPost(entry, assets));
+
+    await setCachedPosts(posts);
+
+    return posts;
+  } catch (error) {
+    console.error('Failed to fetch blog posts from Contentful:', error);
+
+    if (cachedBlogData?.posts) return cachedBlogData.posts;
+
+    return [];
+  }
+};

--- a/src/types/discover.ts
+++ b/src/types/discover.ts
@@ -34,3 +34,15 @@ export interface PartnerApp {
   url: string;
   logoPath: string;
 }
+
+export interface BlogPost {
+  title: string;
+  slug: string;
+  url: string;
+  excerpt: string;
+  image: string;
+  tags: string[];
+  datePublished: string;
+  readingTime: string;
+  author: string;
+}


### PR DESCRIPTION
## Summary
- Replaced Blog tab placeholder with full Contentful-powered implementation
- Fetches posts from the **Contentful Content Delivery API** (same source as markmind.xyz landing page)
- **Cache-first strategy** (1h TTL) via `chrome.storage.local` — instant loads on repeat opens, stale fallback on network errors
- BlogCard UI with image banner, tag badge, reading time, excerpt, and date
- Cards open `markmind.xyz/blog/{slug}` in a new Chrome tab

## Files changed
| File | Description |
|------|-------------|
| `src/services/blog.ts` | Contentful CDN REST API fetch + cache service |
| `src/components/tabs/BlogTab.tsx` | Full tab with loading, error, and empty states |
| `src/components/tabs/BlogTab.css` | Tab layout and state styles |
| `src/components/tabs/blog/BlogCard.tsx` | Card component with image, meta, excerpt |
| `src/components/tabs/blog/BlogCard.css` | Card styling with design tokens |
| `src/types/discover.ts` | Added `BlogPost` and `PartnerApp` interfaces |
| `src/components/icons/Icons.tsx` | Added `ExternalLinkIcon` |

## Test plan
- [ ] Open extension → Blog tab → verify posts load from Contentful
- [ ] Verify images, tags, reading time, and dates render correctly
- [ ] Click a blog card → verify it opens `markmind.xyz/blog/{slug}` in a new tab
- [ ] Close and reopen popup quickly → verify cached posts load instantly
- [ ] Disconnect network → verify stale cache is served gracefully
- [ ] "Visit our blog" button → verify it opens `markmind.xyz/blog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)