### PR TITLE
feat: Dynamic model selector for AI providers

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -19,6 +19,7 @@ const handleStartOrganize = async (payload: StartOrganizePayload): Promise<void>
 
   const result = await organizeBookmarks(
     payload.serviceId,
+    payload.modelId,
     payload.bookmarks,
     payload.folderTree,
     payload.pathToIdMap

--- a/src/components/ApiKeyPanel/ApiKeyPanel.tsx
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.tsx
@@ -31,6 +31,7 @@ const ApiKeyPanel = ({
     currentService,
     apiKeyInput,
     selectedModel,
+    modelsRefreshTrigger,
     hasExistingKey,
     isEditingKey,
     status,
@@ -52,9 +53,10 @@ const ApiKeyPanel = ({
 
   if (!isOpen) return null;
 
+  const hasProviderSelected = currentService.id !== '';
   const hasModelSelected = selectedModel !== '';
-  const showApiKeyCard = hasModelSelected || hasExistingKey;
-  const showConfiguredState = hasExistingKey && !isEditingKey;
+  const showApiKeyCard = hasProviderSelected || hasExistingKey;
+  const showConfiguredState = hasExistingKey && !isEditingKey && hasModelSelected;
 
   return (
     <div className="api-key-panel active">
@@ -108,6 +110,7 @@ const ApiKeyPanel = ({
           <ServiceSelector
             onServiceChange={handleServiceChange}
             onModelChange={handleModelChange}
+            refreshTrigger={modelsRefreshTrigger}
           />
 
           {showApiKeyCard && (
@@ -148,6 +151,24 @@ const ApiKeyPanel = ({
                     Start Organizing Bookmarks
                     <ArrowRightIcon />
                   </Button>
+
+                  <button
+                    className="api-key-change-link"
+                    onClick={handleStartEditingKey}
+                    type="button"
+                  >
+                    Change API Key
+                  </button>
+                </div>
+              ) : hasExistingKey && !isEditingKey ? (
+                <div className="api-key-configured">
+                  <div className="api-key-configured-badge">
+                    <CheckCircleIcon width={20} height={20} />
+                    <div className="api-key-configured-info">
+                      <h3 className="api-key-configured-title">API Key Configured</h3>
+                      <p className="api-key-configured-subtitle">Select a model above to continue</p>
+                    </div>
+                  </div>
 
                   <button
                     className="api-key-change-link"

--- a/src/components/ServiceSelector/ServiceSelector.css
+++ b/src/components/ServiceSelector/ServiceSelector.css
@@ -10,3 +10,45 @@
   gap: var(--spacing-md);
   margin-bottom: var(--spacing-md);
 }
+
+.service-selector-model-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.service-selector-model-row .dropdown {
+  flex: 1;
+}
+
+.service-selector-model-spinner {
+  display: flex;
+  align-items: center;
+  padding-bottom: var(--spacing-xs);
+  color: var(--color-text-light);
+}
+
+.service-selector-refresh {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm);
+  margin-bottom: var(--spacing-2xs);
+  border: none;
+  background: none;
+  color: var(--color-text-light);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.service-selector-refresh:hover {
+  color: var(--color-text);
+  background-color: var(--color-surface);
+}
+
+.service-selector-error {
+  font-size: var(--font-size-2xs);
+  color: var(--color-error);
+  margin: 0;
+}

--- a/src/components/ServiceSelector/ServiceSelector.tsx
+++ b/src/components/ServiceSelector/ServiceSelector.tsx
@@ -1,56 +1,138 @@
 import { useEffect, useState, useCallback } from 'react';
 import {
   SERVICES,
-  DEFAULT_SERVICE_ID,
   SELECTED_SERVICE_STORAGE_KEY,
   SELECTED_MODEL_STORAGE_KEY,
+  MODELS_CACHE_KEY_PREFIX,
   getServiceIds,
 } from '../../config/services';
 import { setSelectedServiceId, setSelectedModelId } from '../../services/selectedState';
+import { fetchModelsForProvider } from '../../services/ai/providerUtils';
+import { type ModelOption } from '../../types/services';
+import { SpinnerIcon, RefreshIcon } from '../icons/Icons';
 import Dropdown from '../Dropdown/Dropdown';
+import Button from '../Button/Button';
 import './ServiceSelector.css';
 
 const getPerProviderModelKey = (serviceId: string): string =>
   `${SELECTED_MODEL_STORAGE_KEY}_${serviceId}`;
 
+const MODELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
 interface ServiceSelectorProps {
   onServiceChange: (serviceId: string) => void;
   onModelChange: (modelId: string) => void;
+  refreshTrigger?: number;
 }
 
 const ServiceSelector = ({
   onServiceChange,
   onModelChange,
+  refreshTrigger = 0,
 }: ServiceSelectorProps) => {
   const [currentServiceId, setCurrentServiceId] = useState<string>('');
   const [currentModelId, setCurrentModelId] = useState<string>('');
+  const [availableModels, setAvailableModels] = useState<ModelOption[]>([]);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [modelsError, setModelsError] = useState('');
+
+  const loadModelsForService = useCallback(async (serviceId: string): Promise<ModelOption[]> => {
+    const service = SERVICES[serviceId];
+    if (!service) return [];
+
+    const storageResult = await chrome.storage.local.get([service.storageKey]);
+    const apiKey = storageResult[service.storageKey];
+
+    if (!apiKey) {
+      setAvailableModels([]);
+      return [];
+    }
+
+    const cacheKey = `${MODELS_CACHE_KEY_PREFIX}${serviceId}`;
+    const cachedResult = await chrome.storage.local.get([cacheKey]);
+    const cached = cachedResult[cacheKey] as { models: ModelOption[]; fetchedAt: number } | undefined;
+
+    if (cached && Date.now() - cached.fetchedAt < MODELS_CACHE_TTL_MS) {
+      setAvailableModels(cached.models);
+      return cached.models;
+    }
+
+    setIsLoadingModels(true);
+    setModelsError('');
+
+    try {
+      const models = await fetchModelsForProvider(serviceId, apiKey);
+      setAvailableModels(models);
+      await chrome.storage.local.set({
+        [cacheKey]: { models, fetchedAt: Date.now() },
+      });
+      return models;
+    } catch (error) {
+      console.error('Failed to fetch models:', error);
+      if (cached?.models) {
+        setAvailableModels(cached.models);
+        return cached.models;
+      }
+      setModelsError('Could not load models. Check your API key.');
+      setAvailableModels([]);
+      return [];
+    } finally {
+      setIsLoadingModels(false);
+    }
+  }, []);
+
+  const selectModel = useCallback(async (serviceId: string, modelId: string): Promise<void> => {
+    setCurrentModelId(modelId);
+    setSelectedModelId(modelId);
+    await chrome.storage.local.set({
+      [getPerProviderModelKey(serviceId)]: modelId,
+      [SELECTED_MODEL_STORAGE_KEY]: modelId,
+    });
+    onModelChange(modelId);
+  }, [onModelChange]);
+
+  const restoreOrFirstAvailableModel = useCallback(async (serviceId: string, models: ModelOption[]): Promise<void> => {
+    if (models.length === 0) return;
+
+    const perProviderKey = getPerProviderModelKey(serviceId);
+    const result = await chrome.storage.local.get([perProviderKey]);
+    const savedModel = result[perProviderKey] as string | undefined;
+
+    const matchesSaved = savedModel && models.some((model) => model.id === savedModel);
+    const modelToSelect = matchesSaved ? savedModel : models[0].id;
+
+    await selectModel(serviceId, modelToSelect);
+  }, [selectModel]);
 
   useEffect(() => {
     const loadSavedSelectionsFromStorage = async (): Promise<void> => {
-      const result = await chrome.storage.local.get([
-        SELECTED_SERVICE_STORAGE_KEY,
-        SELECTED_MODEL_STORAGE_KEY,
-      ]);
-
+      const result = await chrome.storage.local.get([SELECTED_SERVICE_STORAGE_KEY]);
       const savedServiceId = result[SELECTED_SERVICE_STORAGE_KEY];
-      const savedModelId = result[SELECTED_MODEL_STORAGE_KEY];
 
       if (savedServiceId && SERVICES[savedServiceId]) {
         setCurrentServiceId(savedServiceId);
         setSelectedServiceId(savedServiceId);
         onServiceChange(savedServiceId);
 
-        const service = SERVICES[savedServiceId];
-        if (savedModelId && service.models.some(model => model.id === savedModelId)) {
-          setCurrentModelId(savedModelId);
-          setSelectedModelId(savedModelId);
-          onModelChange(savedModelId);
-        }
+        const models = await loadModelsForService(savedServiceId);
+        await restoreOrFirstAvailableModel(savedServiceId, models);
       }
     };
 
     loadSavedSelectionsFromStorage();
-  }, [onServiceChange, onModelChange]);
+  }, [onServiceChange, loadModelsForService, restoreOrFirstAvailableModel]);
+
+  // Reload models when API key is saved (handleApiKeySave caches them first)
+  useEffect(() => {
+    if (refreshTrigger === 0 || !currentServiceId) return;
+
+    const reloadModels = async (): Promise<void> => {
+      const models = await loadModelsForService(currentServiceId);
+      await restoreOrFirstAvailableModel(currentServiceId, models);
+    };
+
+    reloadModels();
+  }, [refreshTrigger, currentServiceId, loadModelsForService, restoreOrFirstAvailableModel]);
 
   const handleProviderSelect = useCallback(async (serviceId: string): Promise<void> => {
     if (!SERVICES[serviceId]) return;
@@ -60,50 +142,42 @@ const ServiceSelector = ({
     await chrome.storage.local.set({ [SELECTED_SERVICE_STORAGE_KEY]: serviceId });
     onServiceChange(serviceId);
 
-    const perProviderKey = getPerProviderModelKey(serviceId);
-    const result = await chrome.storage.local.get([perProviderKey]);
-    const savedModel = result[perProviderKey];
+    setCurrentModelId('');
+    setSelectedModelId('');
+    setAvailableModels([]);
+    setModelsError('');
+    onModelChange('');
 
-    const service = SERVICES[serviceId];
-    if (savedModel && service.models.some(model => model.id === savedModel)) {
-      setCurrentModelId(savedModel);
-      setSelectedModelId(savedModel);
-      await chrome.storage.local.set({ [SELECTED_MODEL_STORAGE_KEY]: savedModel });
-      onModelChange(savedModel);
-    } else {
-      setCurrentModelId('');
-      setSelectedModelId('');
-      await chrome.storage.local.set({ [SELECTED_MODEL_STORAGE_KEY]: '' });
-      onModelChange('');
-    }
-  }, [onServiceChange, onModelChange]);
+    const models = await loadModelsForService(serviceId);
+    await restoreOrFirstAvailableModel(serviceId, models);
+  }, [onServiceChange, onModelChange, loadModelsForService, restoreOrFirstAvailableModel]);
 
   const handleModelSelect = useCallback(async (modelId: string): Promise<void> => {
-    setCurrentModelId(modelId);
-    setSelectedModelId(modelId);
     if (currentServiceId) {
       setSelectedServiceId(currentServiceId);
-      await chrome.storage.local.set({
-        [getPerProviderModelKey(currentServiceId)]: modelId,
-        [SELECTED_MODEL_STORAGE_KEY]: modelId,
-      });
+      await selectModel(currentServiceId, modelId);
     }
-    onModelChange(modelId);
-  }, [currentServiceId, onModelChange]);
+  }, [currentServiceId, selectModel]);
+
+  const handleRefreshModels = useCallback(async (): Promise<void> => {
+    if (!currentServiceId) return;
+    const cacheKey = `${MODELS_CACHE_KEY_PREFIX}${currentServiceId}`;
+    await chrome.storage.local.remove([cacheKey]);
+    const models = await loadModelsForService(currentServiceId);
+    await restoreOrFirstAvailableModel(currentServiceId, models);
+  }, [currentServiceId, loadModelsForService, restoreOrFirstAvailableModel]);
 
   const hasProvider = currentServiceId !== '';
-  const currentService = hasProvider
-    ? SERVICES[currentServiceId] || SERVICES[DEFAULT_SERVICE_ID]
-    : null;
 
   const providerOptions = getServiceIds().map((serviceId) => ({
     id: serviceId,
     label: SERVICES[serviceId].name,
   }));
 
-  const modelOptions = currentService
-    ? currentService.models.map((model) => ({ id: model.id, label: model.name }))
-    : [];
+  const modelOptions = availableModels.map((model) => ({
+    id: model.id,
+    label: model.name,
+  }));
 
   return (
     <div className="service-selector">
@@ -114,14 +188,34 @@ const ServiceSelector = ({
         onSelect={handleProviderSelect}
         placeholder="Select a provider..."
       />
-      <Dropdown
-        label="Model"
-        options={modelOptions}
-        selectedId={currentModelId}
-        onSelect={handleModelSelect}
-        placeholder="Select a model..."
-        disabled={!hasProvider}
-      />
+      <div className="service-selector-model-row">
+        <Dropdown
+          label="Model"
+          options={modelOptions}
+          selectedId={currentModelId}
+          onSelect={handleModelSelect}
+          placeholder={isLoadingModels ? 'Loading models...' : modelsError || 'Select a model...'}
+          disabled={!hasProvider || isLoadingModels || availableModels.length === 0}
+        />
+        {isLoadingModels && (
+          <div className="service-selector-model-spinner">
+            <SpinnerIcon width={12} height={12} />
+          </div>
+        )}
+        {!isLoadingModels && availableModels.length > 0 && (
+          <Button
+            variant="icon"
+            className="service-selector-refresh"
+            onClick={handleRefreshModels}
+            title="Refresh models"
+          >
+            <RefreshIcon width={12} height={12} />
+          </Button>
+        )}
+      </div>
+      {modelsError && (
+        <p className="service-selector-error">{modelsError}</p>
+      )}
     </div>
   );
 };

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -1,7 +1,6 @@
-import { type ServiceConfig, type ServiceTestConfig } from '../types/services';
-import { hasArrayWithItems } from '../utils/helpers';
+import { type ServiceConfig } from '../types/services';
 
-export type { ServiceConfig, ServiceTestConfig };
+export type { ServiceConfig };
 
 export const SERVICES: Record<string, ServiceConfig> = {
   google: {
@@ -12,21 +11,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your Gemini API key',
     helpLink: 'https://aistudio.google.com/apikey',
     helpLinkText: 'Google AI Studio',
-    models: [
-      { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', isDefault: true },
-      { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash', isDefault: false },
-      { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', isDefault: false },
-      { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', isDefault: false },
-    ],
     freeTierNote: 'Free tier has rate limits. Some models (e.g. Pro) may require a paid plan or have very low daily quotas.',
     validateKey: (key: string) => key.startsWith('AI') && key.length >= 30,
-    testConfig: {
-      getEndpoint: (apiKey: string, model?: string) =>
-        `https://generativelanguage.googleapis.com/v1beta/models/${model || 'gemini-2.5-flash'}:generateContent?key=${apiKey}`,
-      getHeaders: () => ({ 'Content-Type': 'application/json' }),
-      getBody: () => ({ contents: [{ parts: [{ text: 'Hi' }] }] }),
-      validateResponse: (data: unknown) => hasArrayWithItems(data, 'candidates'),
-    },
   },
   openai: {
     id: 'openai',
@@ -36,29 +22,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your OpenAI API key',
     helpLink: 'https://platform.openai.com/api-keys',
     helpLinkText: 'OpenAI Platform',
-    models: [
-      { id: 'gpt-4o-mini', name: 'GPT-4o Mini', isDefault: true },
-      { id: 'gpt-4.1-nano', name: 'GPT-4.1 Nano', isDefault: false },
-      { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', isDefault: false },
-      { id: 'gpt-4.1', name: 'GPT-4.1', isDefault: false },
-      { id: 'gpt-5-mini', name: 'GPT-5 Mini', isDefault: false },
-      { id: 'gpt-5', name: 'GPT-5', isDefault: false },
-      { id: 'gpt-5.2', name: 'GPT-5.2', isDefault: false },
-    ],
     validateKey: (key: string) => key.startsWith('sk-') && key.length >= 30,
-    testConfig: {
-      getEndpoint: () => 'https://api.openai.com/v1/chat/completions',
-      getHeaders: (apiKey: string) => ({
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      }),
-      getBody: (model: string) => ({
-        model,
-        messages: [{ role: 'user', content: 'Hi' }],
-        max_tokens: 5,
-      }),
-      validateResponse: (data: unknown) => hasArrayWithItems(data, 'choices'),
-    },
   },
   anthropic: {
     id: 'anthropic',
@@ -68,29 +32,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your Anthropic API key',
     helpLink: 'https://console.anthropic.com/settings/keys',
     helpLinkText: 'Anthropic Console',
-    models: [
-      { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', isDefault: true },
-      { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', isDefault: false },
-      { id: 'claude-sonnet-4-5-20250514', name: 'Claude Sonnet 4.5', isDefault: false },
-      { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', isDefault: false },
-      { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', isDefault: false },
-    ],
     validateKey: (key: string) => key.startsWith('sk-ant-') && key.length >= 30,
-    testConfig: {
-      getEndpoint: () => 'https://api.anthropic.com/v1/messages',
-      getHeaders: (apiKey: string) => ({
-        'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-        'anthropic-dangerous-direct-browser-access': 'true',
-      }),
-      getBody: (model: string) => ({
-        model,
-        max_tokens: 5,
-        messages: [{ role: 'user', content: 'Hi' }],
-      }),
-      validateResponse: (data: unknown) => hasArrayWithItems(data, 'content'),
-    },
   },
   openrouter: {
     id: 'openrouter',
@@ -100,38 +42,14 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your OpenRouter API key',
     helpLink: 'https://openrouter.ai/keys',
     helpLinkText: 'OpenRouter Dashboard',
-    models: [
-      { id: 'anthropic/claude-haiku-4.5', name: 'Claude Haiku 4.5', isDefault: true },
-      { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', isDefault: false },
-      { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash', isDefault: false },
-      { id: 'deepseek/deepseek-chat', name: 'DeepSeek V3', isDefault: false },
-      { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', isDefault: false },
-      { id: 'moonshotai/kimi-k2', name: 'Kimi K2', isDefault: false },
-      { id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6', isDefault: false },
-      { id: 'openai/gpt-4.1-mini', name: 'GPT-4.1 Mini', isDefault: false },
-      { id: 'openai/gpt-5.2', name: 'GPT-5.2', isDefault: false },
-      { id: 'google/gemini-3-flash-preview', name: 'Gemini 3 Flash', isDefault: false },
-    ],
     validateKey: (key: string) => key.startsWith('sk-or-') && key.length >= 30,
-    testConfig: {
-      getEndpoint: () => 'https://openrouter.ai/api/v1/chat/completions',
-      getHeaders: (apiKey: string) => ({
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      }),
-      getBody: (model: string) => ({
-        model,
-        messages: [{ role: 'user', content: 'Hi' }],
-        max_tokens: 5,
-      }),
-      validateResponse: (data: unknown) => hasArrayWithItems(data, 'choices'),
-    },
   },
 };
 
 export const DEFAULT_SERVICE_ID = 'google';
 export const SELECTED_SERVICE_STORAGE_KEY = 'selectedService';
 export const SELECTED_MODEL_STORAGE_KEY = 'selectedModel';
+export const MODELS_CACHE_KEY_PREFIX = 'cachedModels_';
 
 export const getService = (serviceId: string): ServiceConfig => {
   return SERVICES[serviceId] || SERVICES[DEFAULT_SERVICE_ID];
@@ -139,10 +57,4 @@ export const getService = (serviceId: string): ServiceConfig => {
 
 export const getServiceIds = (): string[] => {
   return Object.keys(SERVICES);
-};
-
-export const getDefaultModel = (serviceId: string): string => {
-  const service = SERVICES[serviceId] || SERVICES[DEFAULT_SERVICE_ID];
-  const defaultModel = service.models.find(model => model.isDefault);
-  return defaultModel ? defaultModel.id : service.models[0].id;
 };

--- a/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
@@ -1,22 +1,19 @@
-import { type ApiKeyPanelHandlerDeps, type ApiKeyPanelStatusMessage, AUTO_CLOSE_DELAY_MS } from '../types';
-import { humanizeApiError } from '../../../utils/helpers';
+import { type ApiKeyPanelHandlerDeps, type ApiKeyPanelStatusMessage } from '../types';
+import { fetchModelsForProvider } from '../../../services/ai/providerUtils';
+import { MODELS_CACHE_KEY_PREFIX } from '../../../config/services';
 
 interface HandleApiKeySaveDeps extends Pick<
   ApiKeyPanelHandlerDeps,
   | 'currentService'
   | 'apiKeyInput'
-  | 'selectedModel'
-  | 'canClosePanel'
   | 'setHasExistingKey'
   | 'setApiKeyInput'
-  | 'setCanClosePanel'
   | 'showStatusMessage'
-  | 'autoCloseTimeoutRef'
 > {
-  handlePanelClose: () => void;
   setStatus: (status: ApiKeyPanelStatusMessage) => void;
   setIsEditingKey: (value: boolean) => void;
   showButtonError: (message: string) => void;
+  onModelsLoaded: () => void;
 }
 
 export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
@@ -24,17 +21,13 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
     const {
       currentService,
       apiKeyInput,
-      selectedModel,
-      canClosePanel,
       setHasExistingKey,
       setApiKeyInput,
-      setCanClosePanel,
       showStatusMessage,
       showButtonError,
-      autoCloseTimeoutRef,
-      handlePanelClose,
       setStatus,
       setIsEditingKey,
+      onModelsLoaded,
     } = deps;
 
     const trimmedKey = apiKeyInput.trim();
@@ -54,47 +47,42 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
       setHasExistingKey(true);
       setApiKeyInput('');
 
-      showStatusMessage('Validating...', 'loading');
+      showStatusMessage('Validating key & loading models...', 'loading');
 
-      const { testConfig } = currentService;
-      const response = await fetch(testConfig.getEndpoint(trimmedKey, selectedModel), {
-        method: 'POST',
-        headers: testConfig.getHeaders(trimmedKey),
-        body: JSON.stringify(testConfig.getBody(selectedModel)),
-      });
+      // Fetching models validates the key implicitly — if the key is invalid, this throws
+      const models = await fetchModelsForProvider(currentService.id, trimmedKey);
 
-      const data = await response.json();
-
-      if (response.ok && testConfig.validateResponse(data)) {
+      if (models.length === 0) {
         setStatus({
-          message: "You're all set!",
-          type: 'success',
-          showGoToApp: true,
-        });
-        setIsEditingKey(false);
-
-        if (!canClosePanel) {
-          setCanClosePanel(true);
-          if (autoCloseTimeoutRef.current) {
-            clearTimeout(autoCloseTimeoutRef.current);
-          }
-          autoCloseTimeoutRef.current = setTimeout(() => {
-            handlePanelClose();
-            autoCloseTimeoutRef.current = null;
-          }, AUTO_CLOSE_DELAY_MS);
-        }
-      } else {
-        const rawMessage = data?.error?.message || 'API key is invalid';
-        setStatus({
-          message: humanizeApiError(rawMessage, response.status),
-          type: 'error',
+          message: 'Key accepted but no models found.',
+          type: 'default',
           showGoToApp: false,
         });
+        return;
       }
+
+      // Cache models so ServiceSelector can read them instantly without re-fetching
+      const cacheKey = `${MODELS_CACHE_KEY_PREFIX}${currentService.id}`;
+      await chrome.storage.local.set({
+        [cacheKey]: { models, fetchedAt: Date.now() },
+      });
+
+      setStatus({
+        message: `Key valid — ${models.length} models available! Select a model below.`,
+        type: 'success',
+        showGoToApp: false,
+      });
+      setIsEditingKey(false);
+
+      // Signal ServiceSelector to reload models from cache
+      onModelsLoaded();
     } catch (error) {
       console.error('Failed to save or validate API key:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Connection failed';
       setStatus({
-        message: 'Connection failed. Key saved but could not validate.',
+        message: errorMessage.includes('401') || errorMessage.includes('403')
+          ? 'Invalid API key. Please check and try again.'
+          : `Validation failed: ${errorMessage}`,
         type: 'error',
         showGoToApp: false,
       });

--- a/src/hooks/apiKeyPanel/types.ts
+++ b/src/hooks/apiKeyPanel/types.ts
@@ -22,19 +22,16 @@ export interface ApiKeyPanelState {
 export interface ApiKeyPanelHandlerDeps {
   currentService: ServiceConfig;
   apiKeyInput: string;
-  selectedModel: string;
   canClosePanel: boolean;
   setApiKeyInput: (value: string) => void;
   setHasExistingKey: (value: boolean) => void;
   setStatus: (status: ApiKeyPanelStatusMessage) => void;
-  setCanClosePanel: (value: boolean) => void;
   setCurrentService: (service: ServiceConfig) => void;
   setSelectedModel: (modelId: string) => void;
   showStatusMessage: (message: string, type: StatusType) => void;
   clearStatus: () => void;
   checkExistingApiKey: (service: ServiceConfig) => Promise<boolean>;
   onClose?: () => void;
-  autoCloseTimeoutRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
 }
 
 export const AUTO_CLOSE_DELAY_MS = 1500;

--- a/src/hooks/apiKeyPanel/useApiKeyPanel.ts
+++ b/src/hooks/apiKeyPanel/useApiKeyPanel.ts
@@ -4,6 +4,7 @@ import { type StatusType } from '../../types/common';
 import {
   type ApiKeyPanelStatusMessage,
   type UseApiKeyPanelProps,
+  AUTO_CLOSE_DELAY_MS,
 } from './types';
 import {
   createHandleApiKeySave,
@@ -29,6 +30,7 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
   const autoCloseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [buttonError, setButtonError] = useState('');
   const buttonErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [modelsRefreshTrigger, setModelsRefreshTrigger] = useState(0);
 
   const checkExistingApiKey = useCallback(async (service: ServiceConfig): Promise<boolean> => {
     const result = await chrome.storage.local.get([service.storageKey]);
@@ -63,7 +65,19 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
 
   const handleModelChange = useCallback((modelId: string): void => {
     setSelectedModel(modelId);
-  }, []);
+
+    // Auto-close after save only for first-time users to guide them to main app
+    if (modelId && !canClosePanel) {
+      setCanClosePanel(true);
+      if (autoCloseTimeoutRef.current) {
+        clearTimeout(autoCloseTimeoutRef.current);
+      }
+      autoCloseTimeoutRef.current = setTimeout(() => {
+        handlePanelClose();
+        autoCloseTimeoutRef.current = null;
+      }, AUTO_CLOSE_DELAY_MS);
+    }
+  }, [canClosePanel, handlePanelClose]);
 
   const showButtonError = useCallback((message: string): void => {
     if (buttonErrorTimeoutRef.current) {
@@ -88,23 +102,23 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
     clearStatus();
   }, [clearStatus]);
 
+  const handleModelsLoaded = useCallback((): void => {
+    setModelsRefreshTrigger((previous) => previous + 1);
+  }, []);
+
   const handleApiKeySave = useMemo(
     () => createHandleApiKeySave({
       currentService,
       apiKeyInput,
-      selectedModel,
-      canClosePanel,
       setHasExistingKey,
       setApiKeyInput,
-      setCanClosePanel,
       showStatusMessage,
       showButtonError,
-      autoCloseTimeoutRef,
-      handlePanelClose,
       setStatus,
       setIsEditingKey,
+      onModelsLoaded: handleModelsLoaded,
     }),
-    [currentService, apiKeyInput, selectedModel, canClosePanel, showStatusMessage, showButtonError, handlePanelClose]
+    [currentService, apiKeyInput, showStatusMessage, showButtonError, handleModelsLoaded]
   );
 
   const handleApiKeyRemove = useMemo(
@@ -171,6 +185,7 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
     currentService,
     apiKeyInput,
     selectedModel,
+    modelsRefreshTrigger,
     hasExistingKey,
     isEditingKey,
     status,

--- a/src/hooks/useBulkOrganize/useBulkOrganize.ts
+++ b/src/hooks/useBulkOrganize/useBulkOrganize.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { SELECTED_SERVICE_STORAGE_KEY } from '../../config/services';
+import { SELECTED_SERVICE_STORAGE_KEY, SELECTED_MODEL_STORAGE_KEY } from '../../config/services';
 import { LOADING_MESSAGES, getNextLoadingMessage } from '../../config/loadingMessages';
 import { type StatusType } from '../../types/common';
 import { type OrganizeSession, type BulkOrganizeResult } from '../../types/organize';
@@ -233,11 +233,17 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
       const bookmarksToOrganize = filterBookmarksByFolders(currentSession.allBookmarks, selectedFolderIds);
       if (bookmarksToOrganize.length === 0) return;
 
-      const storageResult = await chrome.storage.local.get([SELECTED_SERVICE_STORAGE_KEY]);
+      const storageResult = await chrome.storage.local.get([SELECTED_SERVICE_STORAGE_KEY, SELECTED_MODEL_STORAGE_KEY]);
       const serviceId = storageResult[SELECTED_SERVICE_STORAGE_KEY] ?? '';
+      const modelId = storageResult[SELECTED_MODEL_STORAGE_KEY] ?? '';
 
       if (!serviceId) {
         await updateSession({ status: 'error', errorMessage: 'No AI provider selected' });
+        return;
+      }
+
+      if (!modelId) {
+        await updateSession({ status: 'error', errorMessage: 'No model selected. Please select a model in Settings.' });
         return;
       }
 
@@ -253,6 +259,7 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
         type: 'START_ORGANIZE',
         payload: {
           serviceId,
+          modelId,
           bookmarks: bookmarksToOrganize,
           folderTree: currentSession.folderTree,
           pathToIdMap: currentSession.pathToIdMap,

--- a/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
+++ b/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getDefaultModel } from '../../config/services';
 import { LOADING_MESSAGES, getNextLoadingMessage } from '../../config/loadingMessages';
 import { type StatusType } from '../../types/common';
 import { type FolderDataForAI, type PendingSuggestion } from '../../types/bookmarks';
@@ -127,7 +126,12 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
         return;
       }
 
-      const selectedModel = getSelectedModelId() || getDefaultModel(serviceId);
+      const selectedModel = getSelectedModelId();
+
+      if (!selectedModel) {
+        showStatus('Please select a model in Settings first', 'error');
+        return;
+      }
 
       folderDataRef.current = folderData;
 

--- a/src/services/ai/bulkOrganize.ts
+++ b/src/services/ai/bulkOrganize.ts
@@ -2,7 +2,6 @@ import { type FolderPlan, type BookmarkAssignment, type CompactBookmark, type Bu
 import { type FolderPathMap } from '../../types/bookmarks';
 import { BULK_ORGANIZE_SYSTEM_PROMPT, buildBulkOrganizeUserPrompt } from './bulkPrompt';
 import { getApiKey, callProvider } from './providerUtils';
-import { getSelectedModelId } from '../selectedState';
 import { debug } from '../../utils/debug';
 
 // Gemini 2.5 Flash uses "thinking" tokens that count against maxOutputTokens,
@@ -86,6 +85,7 @@ const parseBulkOrganizeResponse = (
 
 export const organizeBookmarks = async (
   serviceId: string,
+  modelId: string,
   bookmarks: CompactBookmark[],
   folderTree: string,
   pathToIdMap: FolderPathMap
@@ -105,7 +105,7 @@ export const organizeBookmarks = async (
     apiKey,
     BULK_ORGANIZE_SYSTEM_PROMPT,
     userPrompt,
-    getSelectedModelId(),
+    modelId,
     ORGANIZE_MAX_TOKENS
   );
 

--- a/src/services/ai/providerUtils.ts
+++ b/src/services/ai/providerUtils.ts
@@ -1,5 +1,27 @@
 import { SERVICES } from '../../config/services';
-import { callGemini, callOpenAI, callAnthropic, callOpenRouter } from './providers';
+import { type ModelOption } from '../../types/services';
+import {
+  callGemini, callOpenAI, callAnthropic, callOpenRouter,
+  fetchGeminiModels, fetchOpenAIModels, fetchAnthropicModels, fetchOpenRouterModels,
+} from './providers';
+
+export const fetchModelsForProvider = async (
+  serviceId: string,
+  apiKey: string
+): Promise<ModelOption[]> => {
+  switch (serviceId) {
+    case 'google':
+      return fetchGeminiModels(apiKey);
+    case 'openai':
+      return fetchOpenAIModels(apiKey);
+    case 'anthropic':
+      return fetchAnthropicModels(apiKey);
+    case 'openrouter':
+      return fetchOpenRouterModels(apiKey);
+    default:
+      throw new Error(`Unsupported service: ${serviceId}`);
+  }
+};
 
 export const getApiKey = async (serviceId: string): Promise<string> => {
   const service = SERVICES[serviceId];

--- a/src/services/ai/providers/anthropic.ts
+++ b/src/services/ai/providers/anthropic.ts
@@ -1,4 +1,32 @@
 import { throwApiResponseError } from '../../../utils/helpers';
+import { type ModelOption } from '../../../types/services';
+
+export const fetchAnthropicModels = async (apiKey: string): Promise<ModelOption[]> => {
+  const response = await fetch('https://api.anthropic.com/v1/models?limit=100', {
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+  });
+
+  if (!response.ok) {
+    await throwApiResponseError('Anthropic', response);
+  }
+
+  const data = await response.json();
+
+  if (!Array.isArray(data?.data)) {
+    throw new Error('Unexpected response from Anthropic models endpoint');
+  }
+
+  return data.data
+    .map((model: Record<string, unknown>) => ({
+      id: model.id as string,
+      name: (model.display_name as string) || (model.id as string),
+    }))
+    .sort((modelA: ModelOption, modelB: ModelOption) => modelA.name.localeCompare(modelB.name));
+};
 
 export const callAnthropic = async (
   apiKey: string,

--- a/src/services/ai/providers/gemini.ts
+++ b/src/services/ai/providers/gemini.ts
@@ -1,4 +1,34 @@
 import { throwApiResponseError } from '../../../utils/helpers';
+import { type ModelOption } from '../../../types/services';
+
+const GEMINI_MODEL_PREFIX = 'models/gemini-';
+
+export const fetchGeminiModels = async (apiKey: string): Promise<ModelOption[]> => {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`
+  );
+
+  if (!response.ok) {
+    await throwApiResponseError('Gemini', response);
+  }
+
+  const data = await response.json();
+
+  if (!Array.isArray(data?.models)) {
+    throw new Error('Unexpected response from Gemini models endpoint');
+  }
+
+  return data.models
+    .filter((model: Record<string, unknown>) => {
+      const name = model.name as string;
+      const methods = model.supportedGenerationMethods as string[] | undefined;
+      return name.startsWith(GEMINI_MODEL_PREFIX) && methods?.includes('generateContent');
+    })
+    .map((model: Record<string, unknown>) => ({
+      id: (model.name as string).replace('models/', ''),
+      name: model.displayName as string,
+    }));
+};
 
 export const callGemini = async (
   apiKey: string,

--- a/src/services/ai/providers/gemini.ts
+++ b/src/services/ai/providers/gemini.ts
@@ -5,7 +5,8 @@ const GEMINI_MODEL_PREFIX = 'models/gemini-';
 
 export const fetchGeminiModels = async (apiKey: string): Promise<ModelOption[]> => {
   const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`
+    'https://generativelanguage.googleapis.com/v1/models',
+    { headers: { 'x-goog-api-key': apiKey } }
   );
 
   if (!response.ok) {
@@ -37,11 +38,14 @@ export const callGemini = async (
   model: string,
   maxTokens?: number
 ): Promise<string> => {
-  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 
   const response = await fetch(endpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': apiKey,
+    },
     body: JSON.stringify({
       systemInstruction: { parts: [{ text: systemPrompt }] },
       contents: [{ parts: [{ text: userPrompt }] }],

--- a/src/services/ai/providers/index.ts
+++ b/src/services/ai/providers/index.ts
@@ -1,4 +1,4 @@
-export { callGemini } from './gemini';
-export { callOpenAI } from './openai';
-export { callAnthropic } from './anthropic';
-export { callOpenRouter } from './openRouter';
+export { callGemini, fetchGeminiModels } from './gemini';
+export { callOpenAI, fetchOpenAIModels } from './openai';
+export { callAnthropic, fetchAnthropicModels } from './anthropic';
+export { callOpenRouter, fetchOpenRouterModels } from './openRouter';

--- a/src/services/ai/providers/openRouter.ts
+++ b/src/services/ai/providers/openRouter.ts
@@ -1,4 +1,37 @@
 import { throwApiResponseError } from '../../../utils/helpers';
+import { type ModelOption } from '../../../types/services';
+
+const OPENROUTER_TEXT_PREFIXES = [
+  'openai/', 'anthropic/', 'google/', 'deepseek/', 'meta-llama/',
+  'mistralai/', 'moonshotai/', 'cohere/', 'qwen/',
+];
+
+export const fetchOpenRouterModels = async (apiKey: string): Promise<ModelOption[]> => {
+  const response = await fetch('https://openrouter.ai/api/v1/models', {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (!response.ok) {
+    await throwApiResponseError('OpenRouter', response);
+  }
+
+  const data = await response.json();
+
+  if (!Array.isArray(data?.data)) {
+    throw new Error('Unexpected response from OpenRouter models endpoint');
+  }
+
+  return data.data
+    .filter((model: Record<string, unknown>) => {
+      const modelId = model.id as string;
+      return OPENROUTER_TEXT_PREFIXES.some((prefix) => modelId.startsWith(prefix));
+    })
+    .map((model: Record<string, unknown>) => ({
+      id: model.id as string,
+      name: (model.name as string) || (model.id as string),
+    }))
+    .sort((modelA: ModelOption, modelB: ModelOption) => modelA.name.localeCompare(modelB.name));
+};
 
 export const callOpenRouter = async (
   apiKey: string,

--- a/src/services/ai/providers/openai.ts
+++ b/src/services/ai/providers/openai.ts
@@ -1,4 +1,34 @@
 import { throwApiResponseError } from '../../../utils/helpers';
+import { type ModelOption } from '../../../types/services';
+
+const OPENAI_CHAT_PREFIXES = ['gpt-', 'o1', 'o3', 'o4', 'chatgpt-'];
+
+export const fetchOpenAIModels = async (apiKey: string): Promise<ModelOption[]> => {
+  const response = await fetch('https://api.openai.com/v1/models', {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (!response.ok) {
+    await throwApiResponseError('OpenAI', response);
+  }
+
+  const data = await response.json();
+
+  if (!Array.isArray(data?.data)) {
+    throw new Error('Unexpected response from OpenAI models endpoint');
+  }
+
+  return data.data
+    .filter((model: Record<string, unknown>) => {
+      const modelId = model.id as string;
+      return OPENAI_CHAT_PREFIXES.some((prefix) => modelId.startsWith(prefix));
+    })
+    .map((model: Record<string, unknown>) => ({
+      id: model.id as string,
+      name: model.id as string,
+    }))
+    .sort((modelA: ModelOption, modelB: ModelOption) => modelA.id.localeCompare(modelB.id));
+};
 
 export const callOpenAI = async (
   apiKey: string,

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -14,6 +14,7 @@ export interface OrganizeMessage {
 
 export interface StartOrganizePayload {
   serviceId: string;
+  modelId: string;
   bookmarks: CompactBookmark[];
   folderTree: string;
   pathToIdMap: FolderPathMap;

--- a/src/types/services.ts
+++ b/src/types/services.ts
@@ -1,14 +1,6 @@
 export interface ModelOption {
   id: string;
   name: string;
-  isDefault: boolean;
-}
-
-export interface ServiceTestConfig {
-  getEndpoint: (apiKey: string, model?: string) => string;
-  getHeaders: (apiKey: string) => Record<string, string>;
-  getBody: (model: string) => Record<string, unknown>;
-  validateResponse: (data: unknown) => boolean;
 }
 
 export interface ServiceConfig {
@@ -19,8 +11,6 @@ export interface ServiceConfig {
   placeholder: string;
   helpLink: string;
   helpLinkText: string;
-  models: ModelOption[];
   freeTierNote?: string;
   validateKey: (key: string) => boolean;
-  testConfig: ServiceTestConfig;
 }


### PR DESCRIPTION
## Summary

- **Remove all hardcoded AI models** from service configs — models are now fetched dynamically from each provider's API using the user's saved API key
- **Add model listing endpoints** for all 4 providers (Gemini, OpenAI, Anthropic, OpenRouter) with smart filtering for chat-capable models only
- **Cache fetched models** in `chrome.storage.local` with 24h TTL and stale-cache fallback on errors
- **Gate the setup flow** on model selection — "Start Organizing" only appears after both API key and model are configured
- **Fix service worker bug** — `modelId` is now passed through the message payload instead of reading from popup-only in-memory state

## Changes

### New: Dynamic Model Fetching
- `providers/gemini.ts` — `fetchGeminiModels()` filtering by `generateContent` support
- `providers/openai.ts` — `fetchOpenAIModels()` filtering by chat model prefixes
- `providers/anthropic.ts` — `fetchAnthropicModels()` with browser-access header
- `providers/openRouter.ts` — `fetchOpenRouterModels()` filtering text-generation models
- `providerUtils.ts` — `fetchModelsForProvider()` dispatcher

### Refactored: ServiceSelector
- Fetches models from cache (or API) when provider is selected
- Per-provider model persistence (remembers last-used model per provider)
- `refreshTrigger` prop pattern to reload models after API key save
- Refresh button to manually invalidate cache

### Refactored: API Key Save Flow
- Validates API key by attempting to fetch models (replaces old `testConfig` endpoint)
- Caches models on successful save for immediate ServiceSelector use
- Three-state UI: input → key saved (pick model) → fully configured

### Fixed: Service Worker Model Access
- `modelId` included in `StartOrganizePayload` message
- `useBulkOrganize` reads `modelId` from `chrome.storage.local` (not in-memory state)
- `organizeBookmarks()` accepts `modelId` as parameter

## Test plan

- [ ] Save a Google Gemini API key → model dropdown populates with available models
- [ ] Save an OpenRouter API key → model dropdown populates with chat models
- [ ] Save an OpenAI API key → model dropdown shows GPT/o-series models
- [ ] Save an Anthropic API key → model dropdown shows Claude models
- [ ] Select a model → "Start Organizing" button appears
- [ ] Switch providers → previous provider's model is remembered
- [ ] Close and reopen popup → provider + model selections are restored
- [ ] Click refresh icon → models are re-fetched from API
- [ ] Run bulk organize → completes successfully (no "No models provided" error)
- [ ] Invalid API key → shows error, no models loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)