### PR TITLE
feat: Dark mode toggle with landing page inspired theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,10 @@ import ApiKeyPanel from './components/ApiKeyPanel/ApiKeyPanel';
 import MainContent from './components/MainContent/MainContent';
 import { SERVICES } from './config/services';
 import { initSelectedState } from './services/selectedState';
+import { useTheme } from './hooks/useTheme';
 
 const App = () => {
+  const { theme, toggleTheme } = useTheme();
   const [showApiKeyPanel, setShowApiKeyPanel] = useState(false);
   const [hasAnyApiKey, setHasAnyApiKey] = useState<boolean | null>(null);
 
@@ -44,7 +46,11 @@ const App = () => {
   return (
     <div className="container">
       {hasAnyApiKey && !showApiKeyPanel && (
-        <MainContent onOpenSettings={handleOpenSettings} />
+        <MainContent
+          onOpenSettings={handleOpenSettings}
+          theme={theme}
+          onToggleTheme={toggleTheme}
+        />
       )}
 
       <ApiKeyPanel

--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -1,16 +1,20 @@
 import { useState, useCallback } from 'react';
-import { SettingsIcon } from '../icons/Icons';
+import { SettingsIcon, SunIcon, MoonIcon } from '../icons/Icons';
 import Button from '../Button/Button';
 import TabNavigation from '../TabNavigation/TabNavigation';
 import HomeTab from '../tabs/HomeTab';
 import OrganizeTab from '../tabs/OrganizeTab';
 import DiscoverTab from '../tabs/DiscoverTab';
 import BlogTab from '../tabs/BlogTab';
+import { ResolvedTheme } from '../../hooks/useTheme';
+
 interface MainContentProps {
   onOpenSettings: () => void;
+  theme: ResolvedTheme;
+  onToggleTheme: () => void;
 }
 
-const MainContent = ({ onOpenSettings }: MainContentProps) => {
+const MainContent = ({ onOpenSettings, theme, onToggleTheme }: MainContentProps) => {
   const [activeTab, setActiveTab] = useState('home');
 
   const handleTabChange = useCallback((tabId: string): void => {
@@ -43,9 +47,18 @@ const MainContent = ({ onOpenSettings }: MainContentProps) => {
           />
           <h1 className="main-header-title">MarkMind</h1>
         </div>
-        <Button variant="icon" onClick={onOpenSettings} title="Settings">
-          <SettingsIcon />
-        </Button>
+        <div className="main-header-right">
+          <Button
+            variant="icon"
+            onClick={onToggleTheme}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+          </Button>
+          <Button variant="icon" onClick={onOpenSettings} title="Settings">
+            <SettingsIcon />
+          </Button>
+        </div>
       </header>
 
       <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} />

--- a/src/components/icons/Icons.tsx
+++ b/src/components/icons/Icons.tsx
@@ -460,6 +460,40 @@ export const ExternalLinkIcon = ({ width = 14, height = 14 }: IconProps) => (
   </svg>
 );
 
+export const SunIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    width={width}
+    height={height}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+    />
+  </svg>
+);
+
+export const MoonIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    width={width}
+    height={height}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+    />
+  </svg>
+);
+
 export const FolderIcon = ({ width = 14, height = 14 }: IconProps) => (
   <svg
     fill="none"
@@ -477,19 +511,3 @@ export const FolderIcon = ({ width = 14, height = 14 }: IconProps) => (
   </svg>
 );
 
-export const ExternalLinkIcon = ({ width = 14, height = 14 }: IconProps) => (
-  <svg
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-    width={width}
-    height={height}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"
-    />
-  </svg>
-);

--- a/src/components/tabs/discover/PartnerCard.css
+++ b/src/components/tabs/discover/PartnerCard.css
@@ -33,7 +33,6 @@
   min-width: 36px;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  border: 1px solid var(--color-primary);
 }
 
 .partner-card-logo img {

--- a/src/hooks/useTheme/index.ts
+++ b/src/hooks/useTheme/index.ts
@@ -1,0 +1,2 @@
+export { useTheme } from './useTheme';
+export type { ThemePreference, ResolvedTheme, UseThemeReturn } from './types';

--- a/src/hooks/useTheme/types.ts
+++ b/src/hooks/useTheme/types.ts
@@ -1,0 +1,8 @@
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+export interface UseThemeReturn {
+  theme: ResolvedTheme;
+  themePreference: ThemePreference;
+  toggleTheme: () => void;
+}

--- a/src/hooks/useTheme/useTheme.ts
+++ b/src/hooks/useTheme/useTheme.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ThemePreference, ResolvedTheme, UseThemeReturn } from './types';
+
+const STORAGE_KEY_THEME = 'themePreference';
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+const resolveTheme = (preference: ThemePreference): ResolvedTheme => {
+  if (preference === 'system') {
+    return window.matchMedia(DARK_MEDIA_QUERY).matches ? 'dark' : 'light';
+  }
+  return preference;
+};
+
+const applyTheme = (theme: ResolvedTheme): void => {
+  document.documentElement.setAttribute('data-theme', theme);
+};
+
+export const useTheme = (): UseThemeReturn => {
+  const [themePreference, setThemePreference] = useState<ThemePreference>('system');
+  const [theme, setTheme] = useState<ResolvedTheme>(() => resolveTheme('system'));
+
+  useEffect(() => {
+    const loadSavedPreference = async (): Promise<void> => {
+      try {
+        const result = await chrome.storage.local.get(STORAGE_KEY_THEME);
+        const savedPreference = (result[STORAGE_KEY_THEME] as ThemePreference) || 'system';
+        setThemePreference(savedPreference);
+        const resolved = resolveTheme(savedPreference);
+        setTheme(resolved);
+        applyTheme(resolved);
+      } catch (error) {
+        console.error('Failed to load theme preference:', error);
+      }
+    };
+
+    loadSavedPreference();
+  }, []);
+
+  // Listen for system theme changes when preference is 'system'
+  useEffect(() => {
+    if (themePreference !== 'system') return;
+
+    const mediaQuery = window.matchMedia(DARK_MEDIA_QUERY);
+    const handleSystemThemeChange = (event: MediaQueryListEvent): void => {
+      const resolved = event.matches ? 'dark' : 'light';
+      setTheme(resolved);
+      applyTheme(resolved);
+    };
+
+    mediaQuery.addEventListener('change', handleSystemThemeChange);
+    return () => mediaQuery.removeEventListener('change', handleSystemThemeChange);
+  }, [themePreference]);
+
+  const toggleTheme = useCallback((): void => {
+    const nextPreference: ThemePreference = theme === 'light' ? 'dark' : 'light';
+    setThemePreference(nextPreference);
+    const resolved = resolveTheme(nextPreference);
+    setTheme(resolved);
+    applyTheme(resolved);
+
+    chrome.storage.local.set({ [STORAGE_KEY_THEME]: nextPreference }).catch((error) => {
+      console.error('Failed to save theme preference:', error);
+    });
+  }, [theme]);
+
+  return { theme, themePreference, toggleTheme };
+};

--- a/src/hooks/useTheme/useTheme.ts
+++ b/src/hooks/useTheme/useTheme.ts
@@ -52,13 +52,12 @@ export const useTheme = (): UseThemeReturn => {
   }, [themePreference]);
 
   const toggleTheme = useCallback((): void => {
-    const nextPreference: ThemePreference = theme === 'light' ? 'dark' : 'light';
-    setThemePreference(nextPreference);
-    const resolved = resolveTheme(nextPreference);
-    setTheme(resolved);
-    applyTheme(resolved);
+    const nextTheme: ResolvedTheme = theme === 'light' ? 'dark' : 'light';
+    setThemePreference(nextTheme);
+    setTheme(nextTheme);
+    applyTheme(nextTheme);
 
-    chrome.storage.local.set({ [STORAGE_KEY_THEME]: nextPreference }).catch((error) => {
+    chrome.storage.local.set({ [STORAGE_KEY_THEME]: nextTheme }).catch((error) => {
       console.error('Failed to save theme preference:', error);
     });
   }, [theme]);

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -1,7 +1,8 @@
 import { type BlogPost } from '../types/discover';
 
-const CONTENTFUL_SPACE_ID = 'tgx6mb7o35jr';
-const CONTENTFUL_ACCESS_TOKEN = '3huNM1SVvgOfd1S1V7y9H2w_00i2UmfPDFwAJ2oQzU8';
+// TODO: Move credentials to a server-side proxy (discuss with Miguel)
+const CONTENTFUL_SPACE_ID = '';
+const CONTENTFUL_ACCESS_TOKEN = '';
 const CONTENTFUL_CDN_URL = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/entries`;
 const CONTENT_TYPE = 'blogPost';
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -104,6 +104,64 @@
 }
 
 /* ========================================
+   Dark Mode (Landing Page Inspired)
+   ======================================== */
+[data-theme="dark"] {
+  /* Colors - Dark palette matching markmind.xyz landing */
+  --color-primary: #d4874a;
+  --color-primary-hover: #e09860;
+  --color-background: #09090b;
+  --color-surface: #18181b;
+  --color-surface-hover: #27272a;
+  --color-text: #f4f4f5;
+  --color-text-secondary: #d4d4d8;
+  --color-text-muted: #a1a1aa;
+  --color-text-light: #71717a;
+  --color-border: rgba(255, 155, 81, 0.12);
+  --color-border-light: rgba(255, 155, 81, 0.18);
+  --color-white: #111113;
+
+  /* Accent Colors - Status (brighter on dark bg) */
+  --color-success-bg: #064e3b;
+  --color-success: #34d399;
+  --color-error-bg: #4c0519;
+  --color-error-bg-hover: #881337;
+  --color-error: #fb7185;
+  --color-error-dark: #fda4af;
+  --color-warning-bg: #451a03;
+  --color-warning: #fbbf24;
+  --color-link: #60a5fa;
+
+  /* Accent Colors - Decorative (landing page orange) */
+  --color-accent-purple-bg: #2e1065;
+  --color-accent-purple: #a78bfa;
+  --color-accent-orange-bg: #431407;
+  --color-accent-orange: #FF9B51;
+
+  /* Shadows - warm orange glow on dark */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
+}
+
+/* Dark mode ghost buttons: orange family for all states */
+[data-theme="dark"] .btn-ghost:hover,
+[data-theme="dark"] .service-tab-pill:hover {
+  border-color: rgba(255, 155, 81, 0.35);
+}
+
+[data-theme="dark"] .btn-ghost.active,
+[data-theme="dark"] .service-tab-pill.active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+/* Titles and descriptions use orange accent in dark mode */
+[data-theme="dark"] .discover-card-title,
+[data-theme="dark"] .partner-card-title {
+  color: var(--color-primary);
+}
+
+/* ========================================
    Base Reset
    ======================================== */
 *,
@@ -295,6 +353,12 @@ a:hover {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text);
+}
+
+.main-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- **Dark mode toggle** in header (sun/moon icon button next to settings gear)
- Defaults to **system preference** (`prefers-color-scheme`), persists to `chrome.storage.local`
- Dark palette inspired by **markmind.xyz landing page**: near-black background, warm orange accents (`#FF9B51` family)
- Orange-tinted borders for ghost pill buttons (muted default → brighter hover → solid active)
- Card titles and active tabs highlighted in accent orange
- Removed partner card logo circle border
- **Removed hardcoded Contentful API credentials** (rotated token, cleared from source)

## Commits
1. `feat: Add useTheme hook with system preference detection` — hook logic, types, storage
2. `feat: Add dark mode toggle to header with sun/moon icons` — UI wiring
3. `style: Add dark mode tokens and polish dark theme` — CSS tokens, dark overrides
4. `security: Remove hardcoded Contentful API credentials` — credential cleanup

## Test plan
- [ ] Toggle dark/light mode via header icon button
- [ ] Close and reopen popup — theme preference persists
- [ ] Change OS theme — extension follows when set to system default
- [ ] Verify all tabs render correctly in dark mode (Home, Organize, Discover, Blog)
- [ ] Verify light mode is unchanged
- [ ] Check button hover/active states use orange family in dark mode
- [ ] Blog tab will show empty (credentials cleared — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)