### PR TITLE
feat: Group-level folder selection + checkbox UI

### DIFF
--- a/src/components/FolderTreeGroup/FolderTreeGroup.css
+++ b/src/components/FolderTreeGroup/FolderTreeGroup.css
@@ -41,6 +41,10 @@
   flex-shrink: 0;
 }
 
+.folder-tree-group-action {
+  flex-shrink: 0;
+}
+
 .folder-tree-group-count {
   font-size: var(--font-size-2xs);
   color: var(--color-text-light);

--- a/src/components/FolderTreeGroup/FolderTreeGroup.tsx
+++ b/src/components/FolderTreeGroup/FolderTreeGroup.tsx
@@ -7,6 +7,7 @@ interface FolderTreeGroupProps {
   groupName: string;
   itemCount: number;
   badge?: string;
+  headerAction?: ReactNode;
   children: ReactNode;
   defaultExpanded?: boolean;
 }
@@ -15,6 +16,7 @@ const FolderTreeGroup = ({
   groupName,
   itemCount,
   badge,
+  headerAction,
   children,
   defaultExpanded = false,
 }: FolderTreeGroupProps) => {
@@ -36,6 +38,11 @@ const FolderTreeGroup = ({
         </span>
         <span className="folder-tree-group-name">{groupName}</span>
         {badge && <span className="folder-tree-group-badge">{badge}</span>}
+        {headerAction && (
+          <span className="folder-tree-group-action" onClick={event => event.stopPropagation()}>
+            {headerAction}
+          </span>
+        )}
         <span className="folder-tree-group-count">
           {itemCount}
         </span>

--- a/src/components/OrganizePlan/OrganizePlan.css
+++ b/src/components/OrganizePlan/OrganizePlan.css
@@ -57,11 +57,19 @@
 .organize-plan-folder-indicator {
   display: flex;
   align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--spacing-2xs);
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
 }
 
 .organize-plan-folder-row.included .organize-plan-folder-indicator {
   color: var(--color-success);
+  border-color: var(--color-success);
+  background-color: var(--color-success-bg);
 }
 
 .organize-plan-folder-row.excluded .organize-plan-folder-indicator {

--- a/src/components/OrganizeScan/OrganizeScan.css
+++ b/src/components/OrganizeScan/OrganizeScan.css
@@ -71,6 +71,29 @@
   overflow-y: auto;
 }
 
+/* Group-level checkbox in folder group header */
+.organize-scan-group-check {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--spacing-2xs);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+  color: var(--color-success);
+}
+
+.organize-scan-group-check:hover {
+  border-color: var(--color-text-muted);
+}
+
+.organize-scan-group-check.checked {
+  border-color: var(--color-success);
+  background-color: var(--color-success-bg);
+}
+
 .organize-scan-folder-row {
   display: flex;
   align-items: center;
@@ -100,7 +123,15 @@
   width: 14px;
   height: 14px;
   flex-shrink: 0;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--spacing-2xs);
   color: var(--color-success);
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.organize-scan-folder-row.selected .organize-scan-folder-check {
+  border-color: var(--color-success);
+  background-color: var(--color-success-bg);
 }
 
 .organize-scan-folder-path {

--- a/src/components/OrganizeScan/OrganizeScan.tsx
+++ b/src/components/OrganizeScan/OrganizeScan.tsx
@@ -13,6 +13,7 @@ interface OrganizeScanProps {
   bookmarkStats: BookmarkStats | null;
   onStartScan: () => void;
   onToggleFolder: (folderId: string) => void;
+  onToggleGroupFolders: (folderIds: string[]) => void;
   onSelectAll: () => void;
   onDeselectAll: () => void;
   onStartPlanning: () => void;
@@ -29,6 +30,7 @@ const OrganizeScan = ({
   bookmarkStats,
   onStartScan,
   onToggleFolder,
+  onToggleGroupFolders,
   onSelectAll,
   onDeselectAll,
   onStartPlanning,
@@ -97,12 +99,27 @@ const OrganizeScan = ({
               const groupBookmarkCount = group.items.reduce(
                 (total, folder) => total + folder.bookmarkCount, 0
               );
+              const groupFolderIds = group.items.map(folder => folder.folderId);
+              const selectedInGroup = group.items.filter(
+                folder => session.selectedFolderIds?.includes(folder.folderId) ?? false
+              ).length;
+              const allGroupSelected = selectedInGroup === group.items.length;
+              const showGroupToggle = group.items.length > 1;
 
               return (
                 <FolderTreeGroup
                   key={group.groupName}
                   groupName={group.groupName}
                   itemCount={groupBookmarkCount}
+                  headerAction={showGroupToggle ? (
+                    <Button
+                      variant="unstyled"
+                      className={`organize-scan-group-check ${allGroupSelected ? 'checked' : ''}`}
+                      onClick={() => onToggleGroupFolders(groupFolderIds)}
+                    >
+                      {allGroupSelected && <CheckIcon width={10} height={10} />}
+                    </Button>
+                  ) : undefined}
                 >
                   {group.items.map(folder => {
                     const isSelected = session.selectedFolderIds?.includes(folder.folderId) ?? false;

--- a/src/components/icons/Icons.tsx
+++ b/src/components/icons/Icons.tsx
@@ -477,19 +477,3 @@ export const FolderIcon = ({ width = 14, height = 14 }: IconProps) => (
   </svg>
 );
 
-export const ExternalLinkIcon = ({ width = 14, height = 14 }: IconProps) => (
-  <svg
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-    width={width}
-    height={height}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"
-    />
-  </svg>
-);

--- a/src/components/tabs/OrganizeTab.tsx
+++ b/src/components/tabs/OrganizeTab.tsx
@@ -15,6 +15,7 @@ const OrganizeTab = () => {
     statusType,
     handleStartScan,
     handleToggleFolder,
+    handleToggleGroupFolders,
     handleSelectAllFolders,
     handleDeselectAllFolders,
     handleStartOrganizing,
@@ -36,6 +37,7 @@ const OrganizeTab = () => {
           bookmarkStats={bookmarkStats}
           onStartScan={handleStartScan}
           onToggleFolder={handleToggleFolder}
+          onToggleGroupFolders={handleToggleGroupFolders}
           onSelectAll={handleSelectAllFolders}
           onDeselectAll={handleDeselectAllFolders}
           onStartPlanning={handleStartOrganizing}

--- a/src/hooks/useBulkOrganize/types.ts
+++ b/src/hooks/useBulkOrganize/types.ts
@@ -9,6 +9,7 @@ export interface UseBulkOrganizeReturn {
   statusType: StatusType;
   handleStartScan: () => Promise<void>;
   handleToggleFolder: (folderId: string) => void;
+  handleToggleGroupFolders: (folderIds: string[]) => void;
   handleSelectAllFolders: () => void;
   handleDeselectAllFolders: () => void;
   handleStartOrganizing: () => Promise<void>;

--- a/src/hooks/useBulkOrganize/useBulkOrganize.ts
+++ b/src/hooks/useBulkOrganize/useBulkOrganize.ts
@@ -224,6 +224,21 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     });
   }, []);
 
+  const handleToggleGroupFolders = useCallback((folderIds: string[]): void => {
+    setSession(previousSession => {
+      const currentSelected = previousSession.selectedFolderIds ?? [];
+      const allInGroupSelected = folderIds.every(folderId => currentSelected.includes(folderId));
+
+      const updatedFolderIds = allInGroupSelected
+        ? currentSelected.filter(id => !folderIds.includes(id))
+        : [...new Set([...currentSelected, ...folderIds])];
+
+      const updatedSession = { ...previousSession, selectedFolderIds: updatedFolderIds };
+      debouncedSaveSession(updatedSession);
+      return updatedSession;
+    });
+  }, [debouncedSaveSession]);
+
   const handleStartOrganizing = useCallback(async (): Promise<void> => {
     try {
       const currentSession = sessionRef.current;
@@ -411,6 +426,7 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     statusType,
     handleStartScan,
     handleToggleFolder,
+    handleToggleGroupFolders,
     handleSelectAllFolders,
     handleDeselectAllFolders,
     handleStartOrganizing,


### PR DESCRIPTION
## Summary
- **Group-level select/deselect**: When a parent folder group has multiple sub-folders, a checkbox appears in the group header to toggle all sub-folders at once
- **Bordered checkbox UI**: All checkboxes (scan + plan views) now show a visible thin border even when unchecked, improving selection affordance
- **Bugfix**: Removed duplicate `ExternalLinkIcon` that caused TypeScript build failure

## Test plan
- [ ] Open Organize tab → Scan bookmarks → verify group checkbox appears on groups with 2+ sub-folders
- [ ] Click group checkbox → all sub-folders in that group get selected
- [ ] Click again → all get deselected
- [ ] Individual folder toggles still work independently
- [ ] Verify checkbox borders are visible in both light and dark mode
- [ ] Run AI plan → verify bordered checkboxes appear on plan review folders too
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)