### PR TITLE
feat: strengthen primary CTA buttons

### DIFF
--- a/src/components/ApiKeyPanel/ApiKeyPanel.tsx
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.tsx
@@ -147,7 +147,7 @@ const ApiKeyPanel = ({
                     </div>
                   </div>
 
-                  <Button onClick={handleGoToApp} className="btn-go-to-app">
+                  <Button variant="primary" onClick={handleGoToApp} className="btn-go-to-app">
                     Start Organizing Bookmarks
                     <ArrowRightIcon />
                   </Button>
@@ -223,7 +223,7 @@ const ApiKeyPanel = ({
                     <div className="api-key-card-status">
                       <div className={`status ${status.type}`}>{status.message}</div>
                       {status.showGoToApp && (
-                        <Button onClick={handleGoToApp} className="btn-go-to-app">
+                        <Button variant="primary" onClick={handleGoToApp} className="btn-go-to-app">
                           Start Organizing Bookmarks
                           <ArrowRightIcon />
                         </Button>

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -77,9 +77,9 @@
   padding: var(--spacing-lg) var(--spacing-2xl);
   background-color: var(--color-primary);
   border: none;
-  border-radius: var(--radius-md);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-white);
   cursor: pointer;
   transition: all var(--transition-fast);
@@ -91,6 +91,11 @@
 
 .btn-solid:disabled {
   opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-solid.loading {
+  opacity: 0.7;
   cursor: not-allowed;
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -27,11 +27,12 @@ const Button = ({
     if (variant === 'unstyled') return '';
     if (variant === 'icon') return 'btn-icon';
     if (variant === 'tab') return 'service-tab-pill';
+    if (variant === 'primary') return 'btn-solid';
     return 'btn-ghost';
   };
 
   const baseClass = getBaseClass();
-  const variantClass = variant === 'primary' ? 'btn-primary' : variant === 'danger' ? 'btn-danger' : '';
+  const variantClass = variant === 'danger' ? 'btn-danger' : '';
   const widthClass = fullWidth ? 'btn-full' : '';
   const compactClass = compact ? 'btn-compact' : '';
   const activeClass = active ? 'active' : '';

--- a/src/components/CurrentPageCard/CurrentPageCard.tsx
+++ b/src/components/CurrentPageCard/CurrentPageCard.tsx
@@ -95,6 +95,7 @@ const CurrentPageCard = ({
             {pendingSuggestion ? (
               <div className="current-page-card-suggestion-actions">
                 <Button
+                  variant="primary"
                   onClick={onAccept}
                   disabled={isOrganizing}
                   fullWidth
@@ -123,6 +124,7 @@ const CurrentPageCard = ({
               </div>
             ) : (
               <Button
+                variant="primary"
                 onClick={onOrganize}
                 disabled={isOrganizing}
                 className={isOrganizing ? 'loading' : ''}

--- a/src/components/OrganizeComplete/OrganizeComplete.tsx
+++ b/src/components/OrganizeComplete/OrganizeComplete.tsx
@@ -32,7 +32,7 @@ const OrganizeComplete = ({ session, onReset }: OrganizeCompleteProps) => {
         )}
       </div>
 
-      <Button onClick={onReset} fullWidth>
+      <Button variant="primary" onClick={onReset} fullWidth>
         Done
       </Button>
     </OrganizeStatusView>

--- a/src/components/OrganizePlan/OrganizePlan.tsx
+++ b/src/components/OrganizePlan/OrganizePlan.tsx
@@ -84,7 +84,7 @@ const OrganizePlan = ({
       </div>
 
       <div className="organize-plan-actions">
-        <Button onClick={onApprovePlan} disabled={includedCount === 0} fullWidth>
+        <Button variant="primary" onClick={onApprovePlan} disabled={includedCount === 0} fullWidth>
           <CheckIcon />
           Approve Plan ({includedCount})
         </Button>

--- a/src/components/OrganizeReview/OrganizeReview.tsx
+++ b/src/components/OrganizeReview/OrganizeReview.tsx
@@ -80,6 +80,7 @@ const OrganizeReview = ({
 
       <div className="organize-review-actions">
         <Button
+          variant="primary"
           onClick={onApplyMoves}
           disabled={approvedCount === 0}
           fullWidth

--- a/src/components/OrganizeScan/OrganizeScan.tsx
+++ b/src/components/OrganizeScan/OrganizeScan.tsx
@@ -147,6 +147,7 @@ const OrganizeScan = ({
         </div>
 
         <Button
+          variant="primary"
           onClick={onStartPlanning}
           disabled={selectedCount === 0}
           fullWidth
@@ -167,7 +168,7 @@ const OrganizeScan = ({
         <p className="organize-scan-intro-description">
           We'll analyze your bookmarks and organize them into the perfect folder structure for you.
         </p>
-        <Button onClick={onStartScan} fullWidth>
+        <Button variant="primary" onClick={onStartScan} fullWidth>
           Scan My Bookmarks
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Primary CTA buttons now use solid background (`btn-solid`) instead of ghost variant
- Font size increased from 10px to 11px with bold weight (700)
- 9 buttons updated: Save API Key, Start Organizing, Scan My Bookmarks, Organize Selected, Approve Plan, Apply Moves, Accept, Organize this page, Done
- Secondary actions (Start Over, Re-plan, Decline, etc.) remain ghost style

## Test plan
- [ ] Open extension popup — verify "Organize this page" button has solid background
- [ ] Go to Settings — verify "Save API Key" button is solid
- [ ] Go to Bulk Organize — verify "Scan My Bookmarks" is solid
- [ ] After scan — verify "Organize Selected" is solid, "Select All/Deselect All" remain ghost
- [ ] After plan — verify "Approve Plan" is solid, "Re-plan" is ghost
- [ ] After review — verify "Apply Moves" is solid, "Start Over" is ghost
- [ ] Verify disabled state still works (opacity 0.5)
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)