### PR TITLE
feat: merge bulk organize into single review screen + fix apply bug

### DIFF
--- a/spec/spec-design-merge-bulk-organize-review-screens.md
+++ b/spec/spec-design-merge-bulk-organize-review-screens.md
@@ -1,0 +1,266 @@
+---
+title: Merge Bulk Organize Plan & Review into a Single Screen
+version: 1.0
+date_created: 2026-03-18
+owner: Miguel Silva
+tags: design, UX, bulk-organize, simplification
+---
+
+# Introduction
+
+Currently the bulk organize flow has **two separate review screens** after the AI responds:
+
+1. **OrganizePlan** (`reviewing_plan`) — shows proposed folders with include/exclude checkboxes
+2. **OrganizeReview** (`reviewing_assignments`) — shows bookmarks grouped by folder with approve/reject checkboxes
+
+This spec defines the changes needed to **merge these into a single screen** that shows the folder tree with bookmarks inside each folder, allowing the user to review and apply everything in one step.
+
+## 1. Purpose & Scope
+
+**Purpose**: Eliminate the intermediate `reviewing_plan` step. When the AI responds, skip directly to a unified review screen that shows folders **with their assigned bookmarks inside**, so the user can approve/reject at bookmark level and apply in one click.
+
+**Scope**:
+- State machine change in `OrganizeSessionStatus`
+- Hook logic change in `useBulkOrganize`
+- Service worker message handler update
+- UI: retire `OrganizePlan` component usage, enhance `OrganizeReview` to include folder descriptions and "New" badges
+- `OrganizeTab` routing update
+
+**Out of scope**:
+- Changes to the AI prompt or response format
+- Changes to the scan/select flow
+- Changes to the apply/complete/error flows
+- Deleting OrganizePlan component files (can be done in a follow-up cleanup)
+
+**Audience**: Developer implementing the change (AI or human).
+
+## 2. Definitions
+
+| Term | Definition |
+|------|-----------|
+| **Bulk organize** | Feature that organizes multiple bookmarks at once via AI |
+| **OrganizePlan** | Current screen 1: shows proposed folder structure for approval |
+| **OrganizeReview** | Current screen 2: shows bookmark-to-folder assignments for approval |
+| **FolderPlan** | AI response object containing proposed folders with descriptions |
+| **BookmarkAssignment** | AI response object mapping a bookmark to a suggested folder |
+| **State machine** | The `OrganizeSessionStatus` type that drives which screen is shown |
+
+## 3. Requirements, Constraints & Guidelines
+
+### State Machine
+
+- **REQ-001**: Remove `reviewing_plan` from the `OrganizeSessionStatus` type
+- **REQ-002**: When the AI responds (`ORGANIZE_COMPLETE` message), transition directly from `organizing` to `reviewing_assignments`
+- **REQ-003**: The session must still store `folderPlan` data (needed for folder descriptions and `isNew` flags)
+
+### Hook (`useBulkOrganize`)
+
+- **REQ-004**: Remove `handleApprovePlan` handler (no longer needed — there is no plan approval step)
+- **REQ-005**: Remove `handleRejectPlan` handler (replace with a "Re-organize" action on the unified screen that goes back to `selecting`)
+- **REQ-006**: Remove `handleTogglePlanFolder`, `handleToggleGroupPlanFolders`, `handleSelectAllPlanFolders`, `handleDeselectAllPlanFolders` handlers (folder-level toggling is replaced by bookmark-level toggling)
+- **REQ-007**: The `ORGANIZE_COMPLETE` message handler must set status to `reviewing_assignments` (instead of `reviewing_plan`)
+- **REQ-008**: The `handleApplyMoves` logic remains unchanged — it already filters by `isApproved` on assignments
+- **REQ-009**: Add a `handleReOrganize` handler that resets to `selecting` status with `folderPlan: null` and `assignments: []` (same behavior as current `handleRejectPlan`)
+
+### Session Resume
+
+- **REQ-010**: The `resumeSession` logic in `useBulkOrganize` must handle the case where a saved session has `status: 'reviewing_plan'` (from a previous version) — treat it as `reviewing_assignments`
+
+### UI: Enhanced OrganizeReview
+
+- **REQ-011**: Each folder group header must show the folder **description** from `folderPlan.folders` (currently only shows the folder name)
+- **REQ-012**: Each folder group header must show a **"New" badge** if the folder `isNew === true` (currently only shown on individual bookmark rows)
+- **REQ-013**: The AI's `summary` text from `folderPlan.summary` must be shown at the top of the review screen
+- **REQ-014**: Replace the "Start Over" button with two actions: **"Re-organize"** (goes back to `selecting` to re-run AI) and **"Start Over"** (full reset to `idle`)
+- **REQ-015**: Keep existing bookmark-level toggle functionality (checkbox per bookmark, group toggle, select all, deselect all)
+
+### OrganizeTab Routing
+
+- **REQ-016**: Remove the `reviewing_plan` case from the `switch` statement in `OrganizeTab`
+- **REQ-017**: Pass `folderPlan` to `OrganizeReview` as a new prop so it can display folder descriptions and summary
+
+### Cleanup
+
+- **GUD-001**: Remove `OrganizePlan` import from `OrganizeTab.tsx`
+- **GUD-002**: Remove all plan-related handler props from `UseBulkOrganizeReturn` type
+- **CON-001**: Do NOT delete the `OrganizePlan` component files yet — defer to a cleanup task
+
+## 4. Interfaces & Data Contracts
+
+### Modified Type: `OrganizeSessionStatus`
+
+```typescript
+// BEFORE
+export type OrganizeSessionStatus =
+  | 'idle' | 'scanning' | 'selecting' | 'organizing'
+  | 'reviewing_plan' | 'reviewing_assignments'
+  | 'applying' | 'completed' | 'error';
+
+// AFTER
+export type OrganizeSessionStatus =
+  | 'idle' | 'scanning' | 'selecting' | 'organizing'
+  | 'reviewing_assignments'
+  | 'applying' | 'completed' | 'error';
+```
+
+### Modified Props: `OrganizeReviewProps`
+
+```typescript
+// BEFORE
+interface OrganizeReviewProps {
+  assignments: BookmarkAssignment[];
+  onToggleGroupAssignments: (bookmarkIds: string[]) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onToggleAssignment: (bookmarkId: string) => void;
+  onApplyMoves: () => void;
+  onReset: () => void;
+}
+
+// AFTER
+interface OrganizeReviewProps {
+  assignments: BookmarkAssignment[];
+  folderPlan: FolderPlan | null;
+  onToggleGroupAssignments: (bookmarkIds: string[]) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onToggleAssignment: (bookmarkId: string) => void;
+  onApplyMoves: () => void;
+  onReOrganize: () => void;
+  onReset: () => void;
+}
+```
+
+### Modified Return Type: `UseBulkOrganizeReturn`
+
+Remove these handlers:
+- `handleApprovePlan`
+- `handleRejectPlan`
+- `handleTogglePlanFolder`
+- `handleToggleGroupPlanFolders`
+- `handleSelectAllPlanFolders`
+- `handleDeselectAllPlanFolders`
+
+Add this handler:
+- `handleReOrganize: () => void`
+
+### Service Worker Message Handler (unchanged)
+
+The `ORGANIZE_COMPLETE` message payload structure remains the same. Only the resulting status changes from `reviewing_plan` to `reviewing_assignments`.
+
+## 5. Acceptance Criteria
+
+- **AC-001**: Given the user has selected bookmarks and clicked "Organize", When the AI responds successfully, Then the user sees a single review screen showing folders with bookmarks inside (no intermediate plan screen)
+- **AC-002**: Given the review screen is shown, When the user looks at a folder group, Then they see the folder description text and a "New" badge if applicable
+- **AC-003**: Given the review screen is shown, Then the AI summary text is visible at the top
+- **AC-004**: Given the review screen is shown, When the user toggles individual bookmarks off and clicks "Apply", Then only the approved bookmarks are moved
+- **AC-005**: Given the review screen is shown, When the user clicks "Re-organize", Then they return to the selection screen and can re-run the AI
+- **AC-006**: Given the review screen is shown, When the user clicks "Start Over", Then the session resets completely to idle
+- **AC-007**: Given a saved session from a previous version with `status: 'reviewing_plan'`, When the extension resumes, Then it loads as `reviewing_assignments`
+- **AC-008**: Given the user closes the popup during AI analysis and reopens it, When the AI has completed, Then the user lands directly on the unified review screen
+
+## 6. Test Automation Strategy
+
+- **Test Levels**: Manual testing in Chrome (extension context)
+- **Manual Test Checklist**:
+  1. Scan bookmarks, select some, click Organize
+  2. Verify loading screen appears during AI call
+  3. Verify single review screen appears after AI responds (no plan screen)
+  4. Verify folder descriptions and "New" badges show in group headers
+  5. Verify AI summary text at top
+  6. Toggle some bookmarks off, click Apply, verify only approved ones moved
+  7. Test "Re-organize" button returns to selection
+  8. Test "Start Over" button resets to idle
+  9. Close popup during AI call, reopen, verify it resumes correctly
+  10. Test with a build that previously saved a `reviewing_plan` session — verify it loads as `reviewing_assignments`
+
+## 7. Rationale & Context
+
+The two-screen approach was originally designed to let users first approve the folder structure, then approve individual assignments. In practice:
+
+- Users don't want to approve folders in isolation — they want to see **which bookmarks go where**
+- The folder plan screen provides limited value since the real decision is "should this bookmark go to this folder?"
+- Merging the screens reduces friction: one click less to get bookmarks organized
+- The bookmark-level toggle already provides sufficient granularity (if a user doesn't want a folder, they just uncheck all bookmarks in it)
+
+## 8. Dependencies & External Integrations
+
+### Internal Dependencies
+- **INT-001**: `FolderPlan` type from `src/types/organize.ts` — used to pass folder metadata to `OrganizeReview`
+- **INT-002**: Chrome Storage API — session persistence remains unchanged
+- **INT-003**: Service worker message passing — message types unchanged, only resulting state differs
+
+No external dependency changes required.
+
+## 9. Examples & Edge Cases
+
+### Example: Unified Review Screen Structure
+
+```
+[AI Summary: "Organized 15 bookmarks into 4 folders..."]
+
+[Select All] [Deselect All]
+
+v Development Tools (5)                    [New] [x]
+  [x] React Documentation
+  [x] TypeScript Handbook
+  [x] VS Code Extensions
+  [ ] GitHub Actions Guide        <-- user unchecked
+  [x] MDN Web Docs
+
+v Shopping (3)                             [x]
+  [x] Amazon Wishlist
+  [x] Best Buy Deals
+  [x] IKEA Catalog
+
+v AI / Learning (4)                        [New] [x]
+  [x] ChatGPT
+  [x] Anthropic Docs
+  [x] Hugging Face
+  [x] Papers With Code
+
+v Entertainment (3)                        [x]
+  [x] Netflix
+  [x] Spotify
+  [x] YouTube
+
+[Apply 14 Moves]
+[Re-organize]    [Start Over]
+```
+
+### Edge Cases
+
+1. **All bookmarks in one folder unchecked**: The folder still appears in the list but with 0 count. No special handling needed — `handleApplyMoves` already filters by `isApproved`.
+
+2. **Session from old version**: If `session.status === 'reviewing_plan'` is loaded from storage, treat as `reviewing_assignments`. The `folderPlan` and `assignments` data is already present.
+
+3. **Empty folderPlan**: If `folderPlan` is null (shouldn't happen but defensive), show the review without descriptions — same as current behavior.
+
+## 10. Validation Criteria
+
+1. The `reviewing_plan` status no longer exists in the type system (TypeScript compile check)
+2. OrganizeTab has no `reviewing_plan` case in its switch
+3. After AI responds, user sees bookmarks grouped by folder in one screen
+4. Folder descriptions from `folderPlan` are visible in group headers
+5. All bookmark toggle operations work (individual, group, select all, deselect all)
+6. Apply only moves approved bookmarks
+7. Build succeeds with `npm run build` (no TypeScript errors)
+
+## 11. Related Specifications / Further Reading
+
+- [src/types/organize.ts](../src/types/organize.ts) — Type definitions
+- [src/hooks/useBulkOrganize/useBulkOrganize.ts](../src/hooks/useBulkOrganize/useBulkOrganize.ts) — Core hook
+- [src/components/tabs/OrganizeTab.tsx](../src/components/tabs/OrganizeTab.tsx) — Tab routing
+- [src/components/OrganizeReview/OrganizeReview.tsx](../src/components/OrganizeReview/OrganizeReview.tsx) — Review component to enhance
+- [src/components/OrganizePlan/OrganizePlan.tsx](../src/components/OrganizePlan/OrganizePlan.tsx) — Component being retired
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/types/organize.ts` | Remove `reviewing_plan` from status type |
+| `src/hooks/useBulkOrganize/useBulkOrganize.ts` | Remove plan handlers, change `ORGANIZE_COMPLETE` target status, add `handleReOrganize`, update session resume |
+| `src/hooks/useBulkOrganize/types.ts` | Update `UseBulkOrganizeReturn` type |
+| `src/components/tabs/OrganizeTab.tsx` | Remove `reviewing_plan` case, pass `folderPlan` to `OrganizeReview`, remove plan handler props |
+| `src/components/OrganizeReview/OrganizeReview.tsx` | Add `folderPlan` prop, show summary, show folder descriptions and "New" badges in group headers, add "Re-organize" button |
+| `src/components/OrganizeReview/OrganizeReview.css` | Add styles for folder description and summary |

--- a/src/background.ts
+++ b/src/background.ts
@@ -36,7 +36,7 @@ const handleStartOrganize = async (payload: StartOrganizePayload): Promise<void>
 
   const completedSession: OrganizeSession = {
     ...existingSession,
-    status: 'reviewing_plan',
+    status: 'reviewing_assignments',
     folderPlan: result.folderPlan,
     assignments: result.assignments,
     serviceId: payload.serviceId,

--- a/src/components/OrganizeReview/OrganizeReview.css
+++ b/src/components/OrganizeReview/OrganizeReview.css
@@ -4,6 +4,12 @@
   gap: var(--spacing-xl);
 }
 
+.organize-review-ai-summary {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
 .organize-review-summary {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
@@ -20,13 +26,19 @@
   gap: var(--spacing-md);
 }
 
-
 .organize-review-list {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
   max-height: 350px;
   overflow-y: auto;
+}
+
+.organize-review-folder-description {
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-light);
+  padding: var(--spacing-2xs) var(--spacing-md);
+  margin: 0;
 }
 
 .organize-review-item {
@@ -53,7 +65,6 @@
 .organize-review-item.rejected {
   opacity: 0.5;
 }
-
 
 .organize-review-item-title {
   flex: 1;

--- a/src/components/OrganizeReview/OrganizeReview.tsx
+++ b/src/components/OrganizeReview/OrganizeReview.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
-import { type BookmarkAssignment } from '../../types/organize';
+import { type BookmarkAssignment, type FolderPlan } from '../../types/organize';
 import { getLastSegment } from '../../utils/folderDisplay';
+import { RefreshIcon } from '../icons/Icons';
 import FolderTreeGroup from '../FolderTreeGroup/FolderTreeGroup';
 import OrganizeCheckbox from '../OrganizeCheckbox/OrganizeCheckbox';
 import Button from '../Button/Button';
@@ -8,27 +9,40 @@ import './OrganizeReview.css';
 
 interface OrganizeReviewProps {
   assignments: BookmarkAssignment[];
+  folderPlan: FolderPlan | null;
   onToggleGroupAssignments: (bookmarkIds: string[]) => void;
   onSelectAll: () => void;
   onDeselectAll: () => void;
   onToggleAssignment: (bookmarkId: string) => void;
   onApplyMoves: () => void;
+  onReOrganize: () => void;
   onReset: () => void;
 }
 
 const OrganizeReview = ({
   assignments,
+  folderPlan,
   onToggleGroupAssignments,
   onSelectAll,
   onDeselectAll,
   onToggleAssignment,
   onApplyMoves,
+  onReOrganize,
   onReset,
 }: OrganizeReviewProps) => {
   const approvedCount = useMemo(
     () => assignments.filter(assignment => assignment.isApproved).length,
     [assignments]
   );
+
+  const folderDescriptionMap = useMemo(() => {
+    const map = new Map<string, { description: string; isNew: boolean }>();
+    if (!folderPlan) return map;
+    for (const folder of folderPlan.folders) {
+      map.set(folder.path, { description: folder.description, isNew: folder.isNew });
+    }
+    return map;
+  }, [folderPlan]);
 
   const folderGroups = useMemo(() => {
     const groupMap = new Map<string, BookmarkAssignment[]>();
@@ -50,8 +64,12 @@ const OrganizeReview = ({
 
   return (
     <div className="organize-review">
+      {folderPlan?.summary && (
+        <p className="organize-review-ai-summary">{folderPlan.summary}</p>
+      )}
+
       <p className="organize-review-summary">
-        {assignments.length} bookmarks assigned to {folderGroups.length} folder{folderGroups.length !== 1 ? 's' : ''}
+        {assignments.length} bookmark{assignments.length !== 1 ? 's' : ''} assigned to {folderGroups.length} folder{folderGroups.length !== 1 ? 's' : ''}
       </p>
 
       <div className="organize-review-bulk-actions">
@@ -65,6 +83,7 @@ const OrganizeReview = ({
           const approvedInGroup = group.items.filter(item => item.isApproved).length;
           const isFullSelected = approvedInGroup === group.items.length;
           const isPartialSelected = approvedInGroup > 0 && !isFullSelected;
+          const folderMeta = folderDescriptionMap.get(group.fullPath);
 
           const groupCheckbox = (
             <Button
@@ -81,8 +100,12 @@ const OrganizeReview = ({
               key={group.fullPath}
               groupName={group.displayName}
               itemCount={approvedInGroup}
+              badge={folderMeta?.isNew ? 'New' : undefined}
               headerAction={groupCheckbox}
             >
+              {folderMeta?.description && (
+                <p className="organize-review-folder-description">{folderMeta.description}</p>
+              )}
               {group.items.map(assignment => (
                 <Button
                   key={assignment.bookmarkId}
@@ -94,9 +117,6 @@ const OrganizeReview = ({
                     <OrganizeCheckbox state={assignment.isApproved ? 'full' : 'empty'} />
                   </span>
                   <span className="organize-review-item-title">{assignment.bookmarkTitle}</span>
-                  {assignment.isNewFolder && (
-                    <span className="organize-review-new-badge">New</span>
-                  )}
                 </Button>
               ))}
             </FolderTreeGroup>
@@ -112,6 +132,10 @@ const OrganizeReview = ({
           fullWidth
         >
           Apply {approvedCount} Move{approvedCount !== 1 ? 's' : ''}
+        </Button>
+        <Button onClick={onReOrganize} fullWidth>
+          <RefreshIcon />
+          Re-organize
         </Button>
         <Button onClick={onReset} fullWidth>
           Start Over

--- a/src/components/tabs/OrganizeTab.tsx
+++ b/src/components/tabs/OrganizeTab.tsx
@@ -2,7 +2,6 @@ import { useBulkOrganize } from '../../hooks/useBulkOrganize';
 import { SpinnerIcon } from '../icons/Icons';
 import Button from '../Button/Button';
 import OrganizeScan from '../OrganizeScan/OrganizeScan';
-import OrganizePlan from '../OrganizePlan/OrganizePlan';
 import OrganizeReview from '../OrganizeReview/OrganizeReview';
 import OrganizeComplete from '../OrganizeComplete/OrganizeComplete';
 import OrganizeError from '../OrganizeError/OrganizeError';
@@ -20,12 +19,7 @@ const OrganizeTab = () => {
     handleDeselectAll,
     handleStartOrganizing,
     handleCancelOrganizing,
-    handleApprovePlan,
-    handleRejectPlan,
-    handleTogglePlanFolder,
-    handleToggleGroupPlanFolders,
-    handleSelectAllPlanFolders,
-    handleDeselectAllPlanFolders,
+    handleReOrganize,
     handleToggleGroupAssignments,
     handleSelectAllAssignments,
     handleDeselectAllAssignments,
@@ -65,28 +59,17 @@ const OrganizeTab = () => {
         </OrganizeStatusView>
       );
 
-    case 'reviewing_plan':
-      return (
-        <OrganizePlan
-          session={session}
-          onApprovePlan={handleApprovePlan}
-          onRejectPlan={handleRejectPlan}
-          onToggleFolder={handleTogglePlanFolder}
-          onToggleGroupFolders={handleToggleGroupPlanFolders}
-          onSelectAll={handleSelectAllPlanFolders}
-          onDeselectAll={handleDeselectAllPlanFolders}
-        />
-      );
-
     case 'reviewing_assignments':
       return (
         <OrganizeReview
           assignments={session.assignments}
+          folderPlan={session.folderPlan}
           onToggleGroupAssignments={handleToggleGroupAssignments}
           onSelectAll={handleSelectAllAssignments}
           onDeselectAll={handleDeselectAllAssignments}
           onToggleAssignment={handleToggleAssignment}
           onApplyMoves={handleApplyMoves}
+          onReOrganize={handleReOrganize}
           onReset={handleReset}
         />
       );

--- a/src/hooks/useBulkOrganize/types.ts
+++ b/src/hooks/useBulkOrganize/types.ts
@@ -13,12 +13,7 @@ export interface UseBulkOrganizeReturn {
   handleDeselectAll: () => void;
   handleStartOrganizing: () => Promise<void>;
   handleCancelOrganizing: () => void;
-  handleApprovePlan: () => void;
-  handleRejectPlan: () => void;
-  handleTogglePlanFolder: (folderPath: string) => void;
-  handleToggleGroupPlanFolders: (folderPaths: string[]) => void;
-  handleSelectAllPlanFolders: () => void;
-  handleDeselectAllPlanFolders: () => void;
+  handleReOrganize: () => void;
   handleToggleGroupAssignments: (bookmarkIds: string[]) => void;
   handleSelectAllAssignments: () => void;
   handleDeselectAllAssignments: () => void;

--- a/src/hooks/useBulkOrganize/useBulkOrganize.ts
+++ b/src/hooks/useBulkOrganize/useBulkOrganize.ts
@@ -73,6 +73,14 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
           return;
         }
 
+        // Legacy sessions may have 'reviewing_plan' — treat as 'reviewing_assignments'
+        if ((savedSession.status as string) === 'reviewing_plan') {
+          const migratedSession = { ...savedSession, status: 'reviewing_assignments' as const };
+          setSession(migratedSession);
+          await saveOrganizeSession(migratedSession);
+          return;
+        }
+
         // Applying runs in popup context — if popup closed mid-apply, reset to review
         if (savedSession.status === 'applying') {
           const resetSession = { ...savedSession, status: 'reviewing_assignments' as const };
@@ -118,7 +126,7 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
         clearLoadingMessages();
         setSession(previousSession => ({
           ...previousSession,
-          status: 'reviewing_plan',
+          status: 'reviewing_assignments',
           folderPlan: payload.result.folderPlan,
           assignments: payload.result.assignments,
         }));
@@ -305,89 +313,13 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     }
   }, [updateSession, startLoadingMessages, clearLoadingMessages]);
 
-  const handleApprovePlan = useCallback((): void => {
-    const currentSession = sessionRef.current;
-    if (!currentSession.folderPlan) return;
-
-    const excludedPaths = new Set(
-      currentSession.folderPlan.folders
-        .filter(folder => folder.isExcluded)
-        .map(folder => folder.path)
-    );
-
-    const filteredAssignments = excludedPaths.size > 0
-      ? currentSession.assignments.filter(assignment => !excludedPaths.has(assignment.suggestedPath))
-      : currentSession.assignments;
-
-    updateSession({
-      status: 'reviewing_assignments',
-      assignments: filteredAssignments,
-    });
-  }, [updateSession]);
-
-  const handleRejectPlan = useCallback((): void => {
+  const handleReOrganize = useCallback((): void => {
     updateSession({
       status: 'selecting',
       folderPlan: null,
       assignments: [],
     });
   }, [updateSession]);
-
-  const handleTogglePlanFolder = useCallback((folderPath: string): void => {
-    setSession(previousSession => {
-      if (!previousSession.folderPlan) return previousSession;
-
-      const updatedFolders = previousSession.folderPlan.folders.map(folder =>
-        folder.path === folderPath
-          ? { ...folder, isExcluded: !folder.isExcluded }
-          : folder
-      );
-
-      const updatedSession = {
-        ...previousSession,
-        folderPlan: { ...previousSession.folderPlan, folders: updatedFolders },
-      };
-      debouncedSaveSession(updatedSession);
-      return updatedSession;
-    });
-  }, [debouncedSaveSession]);
-
-  const handleToggleGroupPlanFolders = useCallback((folderPaths: string[]): void => {
-    setSession(previousSession => {
-      if (!previousSession.folderPlan) return previousSession;
-      const folderPlan = previousSession.folderPlan;
-      const groupSet = new Set(folderPaths);
-      const allInGroupIncluded = folderPaths.every(path =>
-        !folderPlan.folders.find(folder => folder.path === path)?.isExcluded
-      );
-      const updatedFolders = folderPlan.folders.map(folder =>
-        groupSet.has(folder.path) ? { ...folder, isExcluded: allInGroupIncluded } : folder
-      );
-      const updatedSession = { ...previousSession, folderPlan: { ...folderPlan, folders: updatedFolders } };
-      debouncedSaveSession(updatedSession);
-      return updatedSession;
-    });
-  }, [debouncedSaveSession]);
-
-  const handleSelectAllPlanFolders = useCallback((): void => {
-    setSession(previousSession => {
-      if (!previousSession.folderPlan) return previousSession;
-      const updatedFolders = previousSession.folderPlan.folders.map(folder => ({ ...folder, isExcluded: false }));
-      const updatedSession = { ...previousSession, folderPlan: { ...previousSession.folderPlan, folders: updatedFolders } };
-      debouncedSaveSession(updatedSession);
-      return updatedSession;
-    });
-  }, [debouncedSaveSession]);
-
-  const handleDeselectAllPlanFolders = useCallback((): void => {
-    setSession(previousSession => {
-      if (!previousSession.folderPlan) return previousSession;
-      const updatedFolders = previousSession.folderPlan.folders.map(folder => ({ ...folder, isExcluded: true }));
-      const updatedSession = { ...previousSession, folderPlan: { ...previousSession.folderPlan, folders: updatedFolders } };
-      debouncedSaveSession(updatedSession);
-      return updatedSession;
-    });
-  }, [debouncedSaveSession]);
 
   const handleToggleGroupAssignments = useCallback((bookmarkIds: string[]): void => {
     setSession(previousSession => {
@@ -451,7 +383,7 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
         try {
           let targetFolderId = assignment.suggestedFolderId;
 
-          if (!targetFolderId && assignment.isNewFolder) {
+          if (!targetFolderId) {
             targetFolderId = await createFolderPath(
               assignment.suggestedPath,
               mutablePathToIdMap,
@@ -516,12 +448,7 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     handleDeselectAll,
     handleStartOrganizing,
     handleCancelOrganizing,
-    handleApprovePlan,
-    handleRejectPlan,
-    handleTogglePlanFolder,
-    handleToggleGroupPlanFolders,
-    handleSelectAllPlanFolders,
-    handleDeselectAllPlanFolders,
+    handleReOrganize,
     handleToggleGroupAssignments,
     handleSelectAllAssignments,
     handleDeselectAllAssignments,

--- a/src/services/ai/bulkOrganize.ts
+++ b/src/services/ai/bulkOrganize.ts
@@ -2,6 +2,7 @@ import { type FolderPlan, type BookmarkAssignment, type CompactBookmark, type Bu
 import { type FolderPathMap } from '../../types/bookmarks';
 import { BULK_ORGANIZE_SYSTEM_PROMPT, buildBulkOrganizeUserPrompt } from './bulkPrompt';
 import { getApiKey, callProvider } from './providerUtils';
+import { findFolderIdByAIPath } from '../../utils/folders';
 import { debug } from '../../utils/debug';
 
 // Gemini 2.5 Flash uses "thinking" tokens that count against maxOutputTokens,
@@ -70,7 +71,7 @@ const parseBulkOrganizeResponse = (
         bookmarkUrl: bookmark?.url ?? '',
         currentPath: bookmark?.currentFolderPath ?? '',
         suggestedPath,
-        suggestedFolderId: pathToIdMap[suggestedPath] ?? null,
+        suggestedFolderId: findFolderIdByAIPath(suggestedPath, pathToIdMap) ?? null,
         isNewFolder: newFolderPaths.has(suggestedPath),
         isApproved: true,
       };

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -1,8 +1,8 @@
 import { type BlogPost } from '../types/discover';
 
 // TODO: Move credentials to a server-side proxy (discuss with Miguel)
-const CONTENTFUL_SPACE_ID = '';
-const CONTENTFUL_ACCESS_TOKEN = '';
+const CONTENTFUL_SPACE_ID = import.meta.env.VITE_CONTENTFUL_SPACE_ID ?? '';
+const CONTENTFUL_ACCESS_TOKEN = import.meta.env.VITE_CONTENTFUL_ACCESS_TOKEN ?? '';
 const CONTENTFUL_CDN_URL = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/entries`;
 const CONTENT_TYPE = 'blogPost';
 

--- a/src/types/organize.ts
+++ b/src/types/organize.ts
@@ -5,7 +5,6 @@ export type OrganizeSessionStatus =
   | 'scanning'
   | 'selecting'
   | 'organizing'
-  | 'reviewing_plan'
   | 'reviewing_assignments'
   | 'applying'
   | 'completed'


### PR DESCRIPTION
## Summary

- **Merge plan & review screens**: Eliminates the intermediate `reviewing_plan` step. After AI responds, users go directly to a single review screen showing folders with bookmarks inside, folder descriptions, "New" badges, AI summary, and a "Re-organize" button
- **Fix bulk organize Apply skipping all bookmarks**: `pathToIdMap` lookup failed because AI returns paths without root prefix (e.g. `Shopping` vs `Bookmarks bar/Shopping`). Also removed `isNewFolder` guard so `createFolderPath` always runs as fallback
- **Contentful blog integration**: `blog.ts` now reads credentials from `import.meta.env` instead of hardcoded empty strings

## Files Changed (10)

| File | Change |
|------|--------|
| `src/types/organize.ts` | Remove `reviewing_plan` from status type |
| `src/hooks/useBulkOrganize/types.ts` | Remove plan handlers, add `handleReOrganize` |
| `src/hooks/useBulkOrganize/useBulkOrganize.ts` | Remove plan handlers, skip to `reviewing_assignments`, fix apply fallback, add backward compat for old sessions |
| `src/components/tabs/OrganizeTab.tsx` | Remove `reviewing_plan` case, pass `folderPlan` to review |
| `src/components/OrganizeReview/OrganizeReview.tsx` | Add AI summary, folder descriptions, "New" badges, "Re-organize" button |
| `src/components/OrganizeReview/OrganizeReview.css` | Styles for new elements |
| `src/background.ts` | Status goes to `reviewing_assignments` instead of `reviewing_plan` |
| `src/services/ai/bulkOrganize.ts` | Use `findFolderIdByAIPath` for fuzzy path matching |
| `src/services/blog.ts` | Read Contentful credentials from env vars |
| `spec/spec-design-merge-bulk-organize-review-screens.md` | Design spec |

## Test plan

- [ ] Bulk organize: scan → select → organize → verify single review screen appears (no plan screen)
- [ ] Verify folder descriptions and "New" badges show in review
- [ ] Verify AI summary text at top of review
- [ ] Click Apply → verify bookmarks are actually moved (not skipped)
- [ ] Test "Re-organize" button returns to selection
- [ ] Test "Start Over" button resets to idle
- [ ] Close popup during AI call, reopen → verify resumes correctly
- [ ] Blog tab loads posts from Contentful

🤖 Generated with [Claude Code](https://claude.com/claude-code)