### PR TITLE
feat: improve CurrentPageCard for already-bookmarked pages

### DIFF
--- a/.claude/commands/create-spec.md
+++ b/.claude/commands/create-spec.md
@@ -1,0 +1,118 @@
+# Create Specification
+
+Your goal is to create a new specification file for `$ARGUMENTS`.
+
+The specification file must define the requirements, constraints, and interfaces for the solution components in a manner that is clear, unambiguous, and structured for effective use by Generative AIs. Follow established documentation standards and ensure the content is machine-readable and self-contained.
+
+## Best Practices for AI-Ready Specifications
+
+- Use precise, explicit, and unambiguous language.
+- Clearly distinguish between requirements, constraints, and recommendations.
+- Use structured formatting (headings, lists, tables) for easy parsing.
+- Avoid idioms, metaphors, or context-dependent references.
+- Define all acronyms and domain-specific terms.
+- Include examples and edge cases where applicable.
+- Ensure the document is self-contained and does not rely on external context.
+
+The specification should be saved in the [/spec/](/spec/) directory and named according to the following convention: `spec-[a-z0-9-]+.md`, where the name should be descriptive of the specification's content and starting with the high-level purpose, which is one of [schema, tool, data, infrastructure, process, architecture, or design].
+
+The specification file must be formatted in well formed Markdown.
+
+Specification files must follow the template below, ensuring that all sections are filled out appropriately:
+
+```md
+---
+title: [Concise Title Describing the Specification's Focus]
+version: [Optional: e.g., 1.0, Date]
+date_created: [YYYY-MM-DD]
+last_updated: [Optional: YYYY-MM-DD]
+owner: [Optional: Team/Individual responsible for this spec]
+tags: [Optional: List of relevant tags or categories, e.g., `infrastructure`, `process`, `design`, `app` etc]
+---
+
+# Introduction
+
+[A short concise introduction to the specification and the goal it is intended to achieve.]
+
+## 1. Purpose & Scope
+
+[Provide a clear, concise description of the specification's purpose and the scope of its application. State the intended audience and any assumptions.]
+
+## 2. Definitions
+
+[List and define all acronyms, abbreviations, and domain-specific terms used in this specification.]
+
+## 3. Requirements, Constraints & Guidelines
+
+[Explicitly list all requirements, constraints, rules, and guidelines. Use bullet points or tables for clarity.]
+
+- **REQ-001**: Requirement 1
+- **SEC-001**: Security Requirement 1
+- **[3 LETTERS]-001**: Other Requirement 1
+- **CON-001**: Constraint 1
+- **GUD-001**: Guideline 1
+- **PAT-001**: Pattern to follow 1
+
+## 4. Interfaces & Data Contracts
+
+[Describe the interfaces, APIs, data contracts, or integration points. Use tables or code blocks for schemas and examples.]
+
+## 5. Acceptance Criteria
+
+[Define clear, testable acceptance criteria for each requirement using Given-When-Then format where appropriate.]
+
+- **AC-001**: Given [context], When [action], Then [expected outcome]
+- **AC-002**: The system shall [specific behavior] when [condition]
+- **AC-003**: [Additional acceptance criteria as needed]
+
+## 6. Test Automation Strategy
+
+[Define the testing approach, frameworks, and automation requirements.]
+
+- **Test Levels**: Unit, Integration, End-to-End
+- **Frameworks**: MSTest, FluentAssertions, Moq (for .NET applications)
+- **Test Data Management**: [approach for test data creation and cleanup]
+- **CI/CD Integration**: [automated testing in GitHub Actions pipelines]
+- **Coverage Requirements**: [minimum code coverage thresholds]
+- **Performance Testing**: [approach for load and performance testing]
+
+## 7. Rationale & Context
+
+[Explain the reasoning behind the requirements, constraints, and guidelines. Provide context for design decisions.]
+
+## 8. Dependencies & External Integrations
+
+[Define the external systems, services, and architectural dependencies required for this specification. Focus on **what** is needed rather than **how** it's implemented.]
+
+### External Systems
+- **EXT-001**: [External system name] - [Purpose and integration type]
+
+### Third-Party Services
+- **SVC-001**: [Service name] - [Required capabilities and SLA requirements]
+
+### Infrastructure Dependencies
+- **INF-001**: [Infrastructure component] - [Requirements and constraints]
+
+### Data Dependencies
+- **DAT-001**: [External data source] - [Format, frequency, and access requirements]
+
+### Technology Platform Dependencies
+- **PLT-001**: [Platform/runtime requirement] - [Version constraints and rationale]
+
+### Compliance Dependencies
+- **COM-001**: [Regulatory or compliance requirement] - [Impact on implementation]
+
+**Note**: This section should focus on architectural and business dependencies, not specific package implementations. For example, specify "OAuth 2.0 authentication library" rather than "Microsoft.AspNetCore.Authentication.JwtBearer v6.0.1".
+
+## 9. Examples & Edge Cases
+
+[Code snippets or data examples demonstrating the correct application of the guidelines, including edge cases.]
+
+## 10. Validation Criteria
+
+[List the criteria or tests that must be satisfied for compliance with this specification.]
+
+## 11. Related Specifications / Further Reading
+
+[Link to related specs or relevant external documentation.]
+```

--- a/spec/spec-design-current-page-card-improvements.md
+++ b/spec/spec-design-current-page-card-improvements.md
@@ -1,0 +1,231 @@
+---
+title: "CurrentPageCard Improvements: Re-organize, Expand/Collapse, Adaptive Header, Label Size"
+version: 1.0
+date_created: 2026-03-19
+owner: Max / Miguel
+tags: [design, app, UX, CurrentPageCard, bookmarks]
+---
+
+# Introduction
+
+When a user opens the MarkMind extension on a page they have already bookmarked, the CurrentPageCard displays "Already saved in" with the folder path but provides no further actions. This spec defines four improvements to make the already-bookmarked experience more useful: re-organize support, visual expand/collapse affordance, adaptive header text, and increased label prominence.
+
+## 1. Purpose & Scope
+
+**Purpose**: Improve the CurrentPageCard UX for already-bookmarked pages across four dimensions: re-organization, visual feedback, contextual labeling, and typography.
+
+**Scope**: Changes are limited to the CurrentPageCard component, the BookmarkTreePath component, the useOrganizeBookmark hook, and the bookmarks service. No changes to bulk organize, AI providers, or other tabs.
+
+**Audience**: Developers implementing these changes in the MarkMind Chrome Extension.
+
+**Assumptions**:
+- The existing `moveBookmark` function in `src/services/bookmarks.ts` (line 70-83) is already implemented and tested.
+- The `FolderTreeGroup` component already renders a chevron expand/collapse icon that should be reused.
+- The `BookmarkTreePath` component already wraps `FolderTreeGroup`, which has built-in expand/collapse behavior.
+
+## 2. Definitions
+
+| Term | Definition |
+|------|-----------|
+| **CurrentPageCard** | The card at the top of HomeTab showing info about the active browser tab |
+| **BookmarkTreePath** | Component that renders a folder path as a tree with a label ("Suggested location" or "Already saved in") |
+| **FolderTreeGroup** | Reusable collapsible folder tree component with chevron icon, used across Organize phases and HomeTab |
+| **useOrganizeBookmark** | Hook managing single-page organize flow: page load, AI call, accept/decline |
+| **existingBookmarkPath** | State variable holding the folder path string when the current URL is already bookmarked |
+| **existingBookmarkId** | New state variable (to be added) holding the Chrome bookmark ID for move operations |
+| **PendingSuggestion** | Type representing an AI-suggested folder location pending user approval |
+| **FOUC** | Flash of Unstyled Content |
+
+## 3. Requirements, Constraints & Guidelines
+
+### Subtask 1: Allow re-organizing already saved bookmarks
+
+- **REQ-001**: When a URL is already bookmarked, display a "Re-organize" button below the "Already saved in" tree path.
+- **REQ-002**: Clicking "Re-organize" must call the AI service to suggest a new folder, exactly as for new bookmarks.
+- **REQ-003**: When the user accepts a re-organize suggestion, the bookmark must be **moved** (not duplicated) using `moveBookmark(bookmarkId, targetFolderId)` from `src/services/bookmarks.ts`.
+- **REQ-004**: The hook must store the existing bookmark's Chrome ID (`existingBookmarkId`) so it can be passed to `moveBookmark`.
+- **REQ-005**: After a successful move, update `existingBookmarkPath` to reflect the new location and clear `pendingSuggestion`.
+
+### Subtask 2: Expand/collapse icon on "Already saved in"
+
+- **REQ-006**: The "Already saved in" tree path must show the same chevron expand/collapse icon as other `FolderTreeGroup` instances.
+- **CON-001**: `BookmarkTreePath` already delegates to `FolderTreeGroup` which renders a chevron. Verify this is visible for the "Already saved in" case. If `defaultExpanded` hides the collapsed state, consider starting collapsed so the chevron is meaningful.
+- **GUD-001**: The "Already saved in" `BookmarkTreePath` should render with `defaultExpanded={false}` so the user sees the folder name with a chevron they can click to reveal the bookmark title inside.
+
+### Subtask 3: Adaptive header text
+
+- **REQ-007**: When the current page URL is already bookmarked (`existingBookmarkPath` is set), the card header label must read **"Already bookmarked"** instead of "You're visiting".
+- **REQ-008**: The `GlobeIcon` should change to a `BookmarkIcon` (or `CheckIcon`) when the page is already bookmarked, providing a visual distinction.
+- **GUD-002**: The header text change must happen reactively when `existingBookmarkPath` is set, including after a successful re-organize (the label should remain "Already bookmarked").
+
+### Subtask 4: Increase label text size
+
+- **REQ-009**: The `.current-page-card-label` font size must increase from `var(--font-size-sm)` (11px) to `var(--font-size-lg)` (14px).
+- **GUD-003**: Verify the larger label looks balanced with the 28px icon circle. If needed, increase the icon container size to match.
+
+### Cross-cutting
+
+- **PAT-001**: Follow arrow function pattern for all new handlers.
+- **PAT-002**: Use `useCallback` for any handler passed to child components.
+- **PAT-003**: Use design tokens only (no hardcoded colors, spacing, or font sizes).
+- **PAT-004**: Use the `Button` component (not raw `<button>` elements).
+- **CON-002**: One component per file. Do not add new components inside existing files.
+- **CON-003**: Do not modify `old-version/` directory.
+
+## 4. Interfaces & Data Contracts
+
+### Modified Hook Return Type (`src/hooks/useOrganizeBookmark/types.ts`)
+
+```typescript
+export interface UseOrganizeBookmarkReturn {
+  currentPageData: PageMetadata | null;
+  isLoadingPage: boolean;
+  isOrganizing: boolean;
+  statusMessage: string;
+  statusType: StatusType;
+  pendingSuggestion: PendingSuggestion | null;
+  existingBookmarkPath: string | null;
+  existingBookmarkId: string | null;          // NEW
+  handleOrganizePage: () => Promise<void>;
+  handleAcceptSuggestion: () => Promise<void>;
+  handleDeclineSuggestion: () => void;
+}
+```
+
+### Modified CurrentPageCard Props
+
+```typescript
+interface CurrentPageCardProps {
+  currentPage: PageMetadata | null;
+  isLoadingPage: boolean;
+  isOrganizing: boolean;
+  statusMessage: string;
+  statusType: StatusType;
+  pendingSuggestion: PendingSuggestion | null;
+  existingBookmarkPath: string | null;
+  existingBookmarkId: string | null;          // NEW — needed to distinguish move vs create
+  onOrganize: () => void;
+  onAccept: () => void;
+  onDecline: () => void;
+}
+```
+
+### Bookmark Service (already exists, no changes needed)
+
+```typescript
+// src/services/bookmarks.ts — moveBookmark already exists at line 70-83
+export const moveBookmark = async (
+  bookmarkId: string,
+  destinationFolderId: string
+): Promise<ChromeBookmarkNode>;
+```
+
+## 5. Acceptance Criteria
+
+- **AC-001**: Given a page that is already bookmarked, When the user opens the extension, Then a "Re-organize" button is visible below the "Already saved in" path.
+- **AC-002**: Given a page that is already bookmarked, When the user clicks "Re-organize", Then the AI is called and a new folder suggestion is shown with Accept/Decline buttons.
+- **AC-003**: Given a pending re-organize suggestion, When the user clicks "Accept", Then `moveBookmark` is called (not `createBookmark`) and the bookmark is moved to the new folder.
+- **AC-004**: Given a pending re-organize suggestion, When the user clicks "Accept", Then `existingBookmarkPath` updates to the new folder path and `pendingSuggestion` is cleared.
+- **AC-005**: Given a page that is already bookmarked, When the user views the "Already saved in" section, Then a chevron icon is visible next to the folder path indicating it can be expanded/collapsed.
+- **AC-006**: Given a page that is already bookmarked, When the user opens the extension, Then the card header reads "Already bookmarked" (not "You're visiting").
+- **AC-007**: Given a page that is NOT bookmarked, When the user opens the extension, Then the card header reads "You're visiting" (unchanged behavior).
+- **AC-008**: The `.current-page-card-label` font size is `var(--font-size-lg)` (14px).
+- **AC-009**: After a successful re-organize move, the card returns to the "Already bookmarked" state with the updated folder path and the "Re-organize" button is available again.
+
+## 6. Test Automation Strategy
+
+- **Test Levels**: Manual testing in Chrome with `npm run build` + Load Unpacked
+- **Test Data Management**: Use real Chrome bookmarks (create test bookmarks, navigate to their URLs, verify card behavior)
+- **Scenarios**:
+  1. Open extension on unbookmarked page: "You're visiting" header, "Organize this page" button
+  2. Open extension on bookmarked page: "Already bookmarked" header, "Already saved in" path (collapsed), "Re-organize" button
+  3. Click "Re-organize": AI runs, suggestion appears with Accept/Decline
+  4. Accept suggestion: bookmark moves, path updates, returns to "Already bookmarked" state
+  5. Decline suggestion: returns to "Already bookmarked" state with original path
+  6. Toggle expand/collapse on "Already saved in" path: chevron rotates, bookmark title shows/hides
+
+## 7. Rationale & Context
+
+**Re-organize**: Users frequently discover that their initial bookmarking was in the wrong folder. Forcing them to manually move bookmarks defeats the purpose of an AI organizer. Allowing re-organize leverages the existing AI pipeline and the already-implemented `moveBookmark` service function.
+
+**Expand/collapse icon**: The `FolderTreeGroup` component already renders a chevron, but when `defaultExpanded={true}` is set (current behavior for "Already saved in"), the collapsed state is never seen and the tree feels static. Defaulting to collapsed makes the chevron meaningful and saves vertical space.
+
+**Adaptive header**: "You're visiting" is misleading when the page is already saved. "Already bookmarked" sets the right expectation immediately.
+
+**Label size**: The current `--font-size-sm` (11px) label is too small for the primary identifier on the card. Increasing to `--font-size-lg` (14px) makes it a clear section title.
+
+## 8. Dependencies & External Integrations
+
+### External Systems
+- **EXT-001**: Chrome Bookmarks API — `chrome.bookmarks.move()` for re-organize, `chrome.bookmarks.search()` for finding existing bookmarks.
+
+### Third-Party Services
+- **SVC-001**: AI Provider (Gemini/OpenAI/Anthropic/OpenRouter) — Called to generate folder suggestion during re-organize. Same flow as new bookmark organize.
+
+### Technology Platform Dependencies
+- **PLT-001**: Chrome Manifest V3 — Extension popup context, `chrome.bookmarks` API requires `bookmarks` permission (already declared).
+
+## 9. Examples & Edge Cases
+
+### Edge Case: Bookmark moved externally
+
+```
+User bookmarks a page, then manually moves it in Chrome's bookmark manager.
+Next time they open MarkMind on that page:
+- findBookmarkByUrl still finds it (searches by URL, not folder)
+- existingBookmarkPath resolves from the NEW parentId
+- "Already bookmarked" shows the updated path
+No special handling needed — the existing flow already reads parentId at runtime.
+```
+
+### Edge Case: Bookmark deleted externally during re-organize
+
+```
+User clicks "Re-organize", AI returns suggestion.
+Meanwhile, user deletes the bookmark from Chrome's bookmark manager.
+User clicks "Accept" → moveBookmark is called with a stale bookmarkId.
+chrome.bookmarks.move() will reject → catch block shows error status.
+Recommendation: Show "Bookmark not found — it may have been removed" error.
+```
+
+### Edge Case: Re-organize suggests same folder
+
+```
+AI suggests the same folder the bookmark is already in.
+moveBookmark is still called (Chrome handles no-op moves gracefully).
+User sees the same path after accept — no error, but feels redundant.
+Recommendation: Detect same-folder and show "Already in the best folder!" message
+instead of calling moveBookmark. Compare existingBookmarkPath with suggestion folderPath.
+```
+
+### Flow: Re-organize sequence
+
+```
+1. User opens extension on bookmarked page
+2. Card shows: "Already bookmarked" header + "Already saved in" tree (collapsed) + "Re-organize" button
+3. User clicks "Re-organize"
+4. handleOrganizePage runs → skips the existingBookmark early-return → calls AI
+5. AI returns folderPath → setPendingSuggestion
+6. Card shows: Accept / Decline buttons (same as new bookmark flow)
+7a. Accept → moveBookmark(existingBookmarkId, targetFolderId) → update existingBookmarkPath
+7b. Decline → clear pendingSuggestion → back to step 2
+```
+
+## 10. Validation Criteria
+
+| # | Criterion | Pass Condition |
+|---|-----------|---------------|
+| 1 | Re-organize button visible | Bookmarked page shows "Re-organize" below tree path |
+| 2 | AI called on re-organize | Network request to AI provider visible in DevTools |
+| 3 | Bookmark moved (not duplicated) | After accept, `chrome.bookmarks.search({url})` returns exactly 1 result in the new folder |
+| 4 | Chevron visible | "Already saved in" section shows ArrowRightIcon chevron |
+| 5 | Expand/collapse works | Clicking chevron toggles bookmark title visibility |
+| 6 | Header adapts | "Already bookmarked" for saved pages, "You're visiting" for unsaved |
+| 7 | Label size increased | Computed font-size of `.current-page-card-label` is 14px |
+| 8 | No duplicate bookmarks | Re-organize never creates a second bookmark for the same URL |
+
+## 11. Related Specifications / Further Reading
+
+- [spec-design-merge-bulk-organize-review-screens.md](/spec/spec-design-merge-bulk-organize-review-screens.md) — Related bulk organize UX patterns
+- [CLAUDE.md](/CLAUDE.md) — Project architecture rules and code patterns
+- [Chrome Bookmarks API](https://developer.chrome.com/docs/extensions/reference/api/bookmarks) — `move()`, `search()`, `create()`

--- a/src/components/BookmarkTreePath/BookmarkTreePath.tsx
+++ b/src/components/BookmarkTreePath/BookmarkTreePath.tsx
@@ -9,6 +9,7 @@ interface BookmarkTreePathProps {
   bookmarkTitle: string;
   isNewFolder: boolean;
   label?: string;
+  defaultExpanded?: boolean;
 }
 
 const BookmarkTreePath = ({
@@ -16,6 +17,7 @@ const BookmarkTreePath = ({
   bookmarkTitle,
   isNewFolder,
   label = 'Suggested location',
+  defaultExpanded = true,
 }: BookmarkTreePathProps) => {
   const cleanPath = stripRootSegment(folderPath);
   const displayPath = splitFolderPath(cleanPath).join(' / ');
@@ -27,7 +29,7 @@ const BookmarkTreePath = ({
         groupName={displayPath}
         itemCount={1}
         badge={isNewFolder ? 'New' : undefined}
-        defaultExpanded
+        defaultExpanded={defaultExpanded}
       >
         <div className="bookmark-tree-path-item">
           <DocumentIcon width={10} height={10} />

--- a/src/components/CurrentPageCard/CurrentPageCard.css
+++ b/src/components/CurrentPageCard/CurrentPageCard.css
@@ -27,7 +27,7 @@
 }
 
 .current-page-card-label {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text);
 }

--- a/src/components/CurrentPageCard/CurrentPageCard.tsx
+++ b/src/components/CurrentPageCard/CurrentPageCard.tsx
@@ -1,7 +1,7 @@
 import { type StatusType } from '../../types/common';
 import { type PendingSuggestion } from '../../types/bookmarks';
 import { type PageMetadata } from '../../types/pages';
-import { GlobeIcon, SpinnerIcon, CheckIcon, XIcon } from '../icons/Icons';
+import { GlobeIcon, CheckCircleIcon, SpinnerIcon, CheckIcon, XIcon } from '../icons/Icons';
 import { isHeadingSimilarToTitle } from '../../utils/helpers';
 import Button from '../Button/Button';
 import BookmarkTreePath from '../BookmarkTreePath/BookmarkTreePath';
@@ -15,6 +15,7 @@ interface CurrentPageCardProps {
   statusType: StatusType;
   pendingSuggestion: PendingSuggestion | null;
   existingBookmarkPath: string | null;
+  existingBookmarkId: string | null;
   onOrganize: () => void;
   onAccept: () => void;
   onDecline: () => void;
@@ -28,20 +29,28 @@ const CurrentPageCard = ({
   statusType,
   pendingSuggestion,
   existingBookmarkPath,
+  existingBookmarkId,
   onOrganize,
   onAccept,
   onDecline,
 }: CurrentPageCardProps) => {
   const shouldShowH1 = currentPage?.h1
     && !isHeadingSimilarToTitle(currentPage.title, currentPage.h1);
+  const isAlreadyBookmarked = !!existingBookmarkPath && !pendingSuggestion;
 
   return (
   <div className="current-page-card">
     <div className="current-page-card-header">
       <div className="current-page-card-icon">
-        <GlobeIcon width={14} height={14} />
+        {existingBookmarkPath ? (
+          <CheckCircleIcon width={14} height={14} />
+        ) : (
+          <GlobeIcon width={14} height={14} />
+        )}
       </div>
-      <span className="current-page-card-label">You're visiting</span>
+      <span className="current-page-card-label">
+        {existingBookmarkPath ? 'Already bookmarked' : "You're visiting"}
+      </span>
     </div>
 
     {isLoadingPage ? (
@@ -81,6 +90,7 @@ const CurrentPageCard = ({
             bookmarkTitle={currentPage.title}
             isNewFolder={false}
             label="Already saved in"
+            defaultExpanded={false}
           />
         )}
 
@@ -90,58 +100,58 @@ const CurrentPageCard = ({
           </p>
         )}
 
-        {!existingBookmarkPath && (
-          <div className="current-page-card-actions">
-            {pendingSuggestion ? (
-              <div className="current-page-card-suggestion-actions">
-                <Button
-                  variant="primary"
-                  onClick={onAccept}
-                  disabled={isOrganizing}
-                  fullWidth
-                >
-                  {isOrganizing ? (
-                    <>
-                      <SpinnerIcon />
-                      Saving...
-                    </>
-                  ) : (
-                    <>
-                      <CheckIcon />
-                      Accept
-                    </>
-                  )}
-                </Button>
-                <Button
-                  variant="danger"
-                  onClick={onDecline}
-                  disabled={isOrganizing}
-                  fullWidth
-                >
-                  <XIcon />
-                  Decline
-                </Button>
-              </div>
-            ) : (
+        <div className="current-page-card-actions">
+          {pendingSuggestion ? (
+            <div className="current-page-card-suggestion-actions">
               <Button
                 variant="primary"
-                onClick={onOrganize}
+                onClick={onAccept}
                 disabled={isOrganizing}
-                className={isOrganizing ? 'loading' : ''}
                 fullWidth
               >
                 {isOrganizing ? (
                   <>
                     <SpinnerIcon />
-                    {statusMessage || 'Analyzing...'}
+                    {existingBookmarkId ? 'Moving...' : 'Saving...'}
                   </>
                 ) : (
-                  'Organize this page'
+                  <>
+                    <CheckIcon />
+                    Accept
+                  </>
                 )}
               </Button>
-            )}
-          </div>
-        )}
+              <Button
+                variant="danger"
+                onClick={onDecline}
+                disabled={isOrganizing}
+                fullWidth
+              >
+                <XIcon />
+                Decline
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="primary"
+              onClick={onOrganize}
+              disabled={isOrganizing}
+              className={isOrganizing ? 'loading' : ''}
+              fullWidth
+            >
+              {isOrganizing ? (
+                <>
+                  <SpinnerIcon />
+                  {statusMessage || 'Analyzing...'}
+                </>
+              ) : isAlreadyBookmarked ? (
+                'Re-organize'
+              ) : (
+                'Organize this page'
+              )}
+            </Button>
+          )}
+        </div>
       </>
     )}
   </div>

--- a/src/components/tabs/HomeTab.tsx
+++ b/src/components/tabs/HomeTab.tsx
@@ -17,6 +17,7 @@ const HomeTab = ({ onTabChange, onOpenSettings }: HomeTabProps) => {
     statusType,
     pendingSuggestion,
     existingBookmarkPath,
+    existingBookmarkId,
     handleOrganizePage,
     handleAcceptSuggestion,
     handleDeclineSuggestion,
@@ -33,6 +34,7 @@ const HomeTab = ({ onTabChange, onOpenSettings }: HomeTabProps) => {
         statusType={statusType}
         pendingSuggestion={pendingSuggestion}
         existingBookmarkPath={existingBookmarkPath}
+        existingBookmarkId={existingBookmarkId}
         onOrganize={handleOrganizePage}
         onAccept={handleAcceptSuggestion}
         onDecline={handleDeclineSuggestion}

--- a/src/hooks/useOrganizeBookmark/types.ts
+++ b/src/hooks/useOrganizeBookmark/types.ts
@@ -10,6 +10,7 @@ export interface UseOrganizeBookmarkReturn {
   statusType: StatusType;
   pendingSuggestion: PendingSuggestion | null;
   existingBookmarkPath: string | null;
+  existingBookmarkId: string | null;
   handleOrganizePage: () => Promise<void>;
   handleAcceptSuggestion: () => Promise<void>;
   handleDeclineSuggestion: () => void;

--- a/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
+++ b/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
@@ -7,7 +7,7 @@ import { getFolderDataForAI, findFolderPathById, findFolderIdByAIPath } from '..
 import { organizeBookmark } from '../../services/ai';
 import { getSelectedServiceId, getSelectedModelId } from '../../services/selectedState';
 import { getCurrentPageData } from '../../services/pageMetadata';
-import { findBookmarkByUrl, createBookmark, createFolderPath } from '../../services/bookmarks';
+import { findBookmarkByUrl, createBookmark, moveBookmark, createFolderPath } from '../../services/bookmarks';
 import { type UseOrganizeBookmarkReturn } from './types';
 
 const LOADING_MESSAGE_INTERVAL_MS = 2000;
@@ -21,6 +21,7 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
   const [statusType, setStatusType] = useState<StatusType>('default');
   const [pendingSuggestion, setPendingSuggestion] = useState<PendingSuggestion | null>(null);
   const [existingBookmarkPath, setExistingBookmarkPath] = useState<string | null>(null);
+  const [existingBookmarkId, setExistingBookmarkId] = useState<string | null>(null);
 
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadingMessageIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -33,6 +34,18 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
         const pageData = await getCurrentPageData();
         if (pageData) {
           setCurrentPageData(pageData);
+
+          const existingBookmark = await findBookmarkByUrl(pageData.url);
+          if (existingBookmark) {
+            setExistingBookmarkId(existingBookmark.id);
+            const folderData = await getFolderDataForAI();
+            const folderPath = existingBookmark.parentId
+              ? findFolderPathById(folderData.idToPathMap, existingBookmark.parentId)
+              : null;
+            if (folderPath) {
+              setExistingBookmarkPath(folderPath);
+            }
+          }
         }
       } catch (error) {
         console.error('Error initializing organize bookmark:', error);
@@ -104,22 +117,6 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
       startLoadingMessages();
 
       const folderData = await getFolderDataForAI();
-
-      const existingBookmark = await findBookmarkByUrl(currentPageData.url);
-
-      if (existingBookmark) {
-        const folderPath = existingBookmark.parentId
-          ? findFolderPathById(folderData.idToPathMap, existingBookmark.parentId)
-          : null;
-
-        if (folderPath) {
-          setExistingBookmarkPath(folderPath);
-          clearLoadingMessages();
-        } else {
-          showStatus('Already bookmarked (folder not found in tree)', 'error');
-        }
-        return;
-      }
 
       const serviceId = getSelectedServiceId();
 
@@ -193,15 +190,21 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
         return;
       }
 
-      showStatus('Saving bookmark...', 'default');
-      await createBookmark(
-        targetFolderId,
-        pendingSuggestion.pageTitle,
-        pendingSuggestion.pageUrl
-      );
+      if (existingBookmarkId) {
+        showStatus('Moving bookmark...', 'default');
+        await moveBookmark(existingBookmarkId, targetFolderId);
+        setExistingBookmarkPath(pendingSuggestion.folderPath);
+      } else {
+        showStatus('Saving bookmark...', 'default');
+        await createBookmark(
+          targetFolderId,
+          pendingSuggestion.pageTitle,
+          pendingSuggestion.pageUrl
+        );
+      }
 
       setPendingSuggestion(null);
-      showStatus('Bookmark saved!', 'success');
+      showStatus(existingBookmarkId ? 'Bookmark moved!' : 'Bookmark saved!', 'success');
     } catch (error) {
       console.error('Error saving bookmark:', error);
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -209,7 +212,7 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
     } finally {
       setIsOrganizing(false);
     }
-  }, [pendingSuggestion, showStatus]);
+  }, [pendingSuggestion, existingBookmarkId, showStatus]);
 
   const handleDeclineSuggestion = useCallback((): void => {
     setPendingSuggestion(null);
@@ -224,6 +227,7 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
     statusType,
     pendingSuggestion,
     existingBookmarkPath,
+    existingBookmarkId,
     handleOrganizePage,
     handleAcceptSuggestion,
     handleDeclineSuggestion,


### PR DESCRIPTION
## Summary

- **Re-organize support**: Users can now re-organize already-bookmarked pages. Clicking "Re-organize" calls the AI for a new suggestion; accepting it **moves** the bookmark (no duplicates) via `moveBookmark`
- **Adaptive header**: Card shows "Already bookmarked" with a check icon when the page is saved, "You're visiting" with globe icon otherwise
- **Collapsible "Already saved in"**: Tree path defaults to collapsed so the chevron is meaningful and saves vertical space
- **Larger label**: Card header label bumped from `--font-size-sm` (11px) to `--font-size-lg` (14px) for better readability
- **Spec file**: Added `spec/spec-design-current-page-card-improvements.md` with full requirements, edge cases, and acceptance criteria

## Test plan

- [ ] Open extension on an **unbookmarked** page: shows "You're visiting" + globe icon + "Organize this page" button
- [ ] Open extension on a **bookmarked** page: shows "Already bookmarked" + check icon + collapsed tree path + "Re-organize" button
- [ ] Click "Re-organize": AI runs, suggestion appears with Accept/Decline
- [ ] Accept re-organize: bookmark is **moved** (not duplicated) — verify with `chrome://bookmarks`
- [ ] Decline re-organize: returns to "Already bookmarked" state with original path
- [ ] Expand/collapse "Already saved in" chevron works
- [ ] Label text is visibly larger than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)