### PR TITLE
feat: first-time user onboarding flow for non-technical users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,47 @@
 import { useState, useEffect, useCallback } from 'react';
 import ApiKeyPanel from './components/ApiKeyPanel/ApiKeyPanel';
 import MainContent from './components/MainContent/MainContent';
+import Onboarding from './components/Onboarding/Onboarding';
 import { SERVICES } from './config/services';
 import { initSelectedState } from './services/selectedState';
 import { useTheme } from './hooks/useTheme';
+import {
+  ONBOARDING_COMPLETE_STORAGE_KEY,
+  ONBOARDING_TOOLTIPS_PENDING_KEY,
+  ONBOARDING_TOOLTIPS_SEEN_KEY,
+} from './config/onboarding';
 
 const App = () => {
   const { theme, toggleTheme } = useTheme();
   const [showApiKeyPanel, setShowApiKeyPanel] = useState(false);
   const [hasAnyApiKey, setHasAnyApiKey] = useState<boolean | null>(null);
+  const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(null);
+  const [showOnboardingTooltips, setShowOnboardingTooltips] = useState(false);
 
   const checkForExistingApiKeys = useCallback(async (): Promise<void> => {
     const storageKeys = Object.values(SERVICES).map(
       (service) => service.storageKey
     );
-    const result = await chrome.storage.local.get(storageKeys);
+    const result = await chrome.storage.local.get([
+      ...storageKeys,
+      ONBOARDING_COMPLETE_STORAGE_KEY,
+      ONBOARDING_TOOLTIPS_PENDING_KEY,
+      ONBOARDING_TOOLTIPS_SEEN_KEY,
+    ]);
     const hasKey = storageKeys.some((key) => !!result[key]);
 
     setHasAnyApiKey(hasKey);
+    setOnboardingComplete(!!result[ONBOARDING_COMPLETE_STORAGE_KEY]);
 
-    if (!hasKey) {
+    if (hasKey) {
+      const tooltipsPending = !!result[ONBOARDING_TOOLTIPS_PENDING_KEY];
+      const tooltipsSeen = !!result[ONBOARDING_TOOLTIPS_SEEN_KEY];
+      setShowOnboardingTooltips(tooltipsPending && !tooltipsSeen);
+    }
+
+    if (hasKey) {
+      setShowApiKeyPanel(false);
+    } else if (result[ONBOARDING_COMPLETE_STORAGE_KEY]) {
       setShowApiKeyPanel(true);
     }
 
@@ -39,9 +61,32 @@ const App = () => {
     setShowApiKeyPanel(true);
   }, []);
 
-  if (hasAnyApiKey === null) {
+  const handleOnboardingComplete = useCallback((): void => {
+    checkForExistingApiKeys();
+  }, [checkForExistingApiKeys]);
+
+  const handleEscapeToApiKeyPanel = useCallback((): void => {
+    setOnboardingComplete(true);
+    setShowApiKeyPanel(true);
+  }, []);
+
+  const handleTooltipsDismissed = useCallback(async (): Promise<void> => {
+    setShowOnboardingTooltips(false);
+    try {
+      await chrome.storage.local.set({
+        [ONBOARDING_TOOLTIPS_PENDING_KEY]: false,
+        [ONBOARDING_TOOLTIPS_SEEN_KEY]: true,
+      });
+    } catch (error) {
+      console.error('Failed to mark tooltips as seen:', error);
+    }
+  }, []);
+
+  if (hasAnyApiKey === null || onboardingComplete === null) {
     return null;
   }
+
+  const showOnboarding = !hasAnyApiKey && !onboardingComplete;
 
   return (
     <div className="container">
@@ -50,17 +95,31 @@ const App = () => {
           onOpenSettings={handleOpenSettings}
           theme={theme}
           onToggleTheme={toggleTheme}
+          showOnboardingTooltips={showOnboardingTooltips}
+          onTooltipsDismissed={handleTooltipsDismissed}
         />
       )}
 
-      <ApiKeyPanel
-        isOpen={showApiKeyPanel || !hasAnyApiKey}
-        showWelcomeMessage={!hasAnyApiKey}
-        canClose={hasAnyApiKey}
-        onClose={handleApiKeyPanelClose}
-        theme={theme}
-        onToggleTheme={toggleTheme}
-      />
+      {showOnboarding && (
+        <Onboarding
+          isOpen
+          onComplete={handleOnboardingComplete}
+          onEscapeToApiKeyPanel={handleEscapeToApiKeyPanel}
+          theme={theme}
+          onToggleTheme={toggleTheme}
+        />
+      )}
+
+      {!showOnboarding && (
+        <ApiKeyPanel
+          isOpen={showApiKeyPanel || !hasAnyApiKey}
+          showWelcomeMessage={!hasAnyApiKey}
+          canClose={hasAnyApiKey}
+          onClose={handleApiKeyPanelClose}
+          theme={theme}
+          onToggleTheme={toggleTheme}
+        />
+      )}
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,9 +37,6 @@ const App = () => {
       const tooltipsPending = !!result[ONBOARDING_TOOLTIPS_PENDING_KEY];
       const tooltipsSeen = !!result[ONBOARDING_TOOLTIPS_SEEN_KEY];
       setShowOnboardingTooltips(tooltipsPending && !tooltipsSeen);
-    }
-
-    if (hasKey) {
       setShowApiKeyPanel(false);
     } else if (result[ONBOARDING_COMPLETE_STORAGE_KEY]) {
       setShowApiKeyPanel(true);

--- a/src/components/ApiKeyPanel/ApiKeyPanel.css
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.css
@@ -444,3 +444,65 @@
 .btn-danger-full {
   width: 100%;
 }
+
+/* Setup Guide Link in Header */
+.header-guide-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.header-guide-tooltip {
+  position: absolute;
+  top: calc(100% + var(--spacing-xs));
+  right: 0;
+  white-space: nowrap;
+  font-size: var(--font-size-2xs);
+  color: var(--color-white);
+  background-color: var(--color-primary);
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+}
+
+.header-guide-link:hover .header-guide-tooltip {
+  opacity: 1;
+}
+
+/* Setup Guide View */
+.setup-guide-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.setup-guide-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.setup-guide-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+}
+
+.setup-guide-reassurances {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.setup-guide-reassurance-item {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+  padding: var(--spacing-2xs) 0;
+}
+
+/* Step list classes are shared — see src/styles/index.css (.step-list-*) */

--- a/src/components/ApiKeyPanel/ApiKeyPanel.css
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.css
@@ -471,38 +471,5 @@
   opacity: 1;
 }
 
-/* Setup Guide View */
-.setup-guide-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
-}
-
-.setup-guide-heading {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text);
-  margin: 0;
-}
-
-.setup-guide-text {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  line-height: var(--line-height-relaxed);
-  margin: 0;
-}
-
-.setup-guide-reassurances {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-}
-
-.setup-guide-reassurance-item {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  margin: 0;
-  padding: var(--spacing-2xs) 0;
-}
-
 /* Step list classes are shared — see src/styles/index.css (.step-list-*) */
+/* Setup guide view extracted to components/SetupGuide/ */

--- a/src/components/ApiKeyPanel/ApiKeyPanel.tsx
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import ServiceSelector from '../ServiceSelector/ServiceSelector';
 import Button from '../Button/Button';
+import SetupGuide from '../SetupGuide/SetupGuide';
 import { useApiKeyPanel } from '../../hooks/apiKeyPanel';
 import {
   StarIcon,
@@ -10,11 +11,11 @@ import {
   ShieldIcon,
   CheckCircleIcon,
   InfoIcon,
-  ExternalLinkIcon,
   SunIcon,
   MoonIcon,
 } from '../icons/Icons';
 import Footer from '../Footer/Footer';
+import { AI_STUDIO_URL } from '../../config/onboarding';
 import './ApiKeyPanel.css';
 
 interface ApiKeyPanelProps {
@@ -68,7 +69,7 @@ const ApiKeyPanel = ({
   }, []);
 
   const handleOpenAIStudio = useCallback((): void => {
-    chrome.tabs.create({ url: 'https://aistudio.google.com/apikey' });
+    chrome.tabs.create({ url: AI_STUDIO_URL });
   }, []);
 
   if (!isOpen) return null;
@@ -80,90 +81,10 @@ const ApiKeyPanel = ({
 
   if (showSetupGuide) {
     return (
-      <div className="api-key-panel active">
-        <div className="api-key-panel-content">
-          <header className="api-key-panel-header">
-            <div className="header-settings">
-              <div className="header-left">
-                <Button variant="icon" onClick={handleCloseSetupGuide} title="Back to Settings">
-                  <ArrowLeftIcon />
-                </Button>
-                <h2 className="header-title">Setup Guide</h2>
-              </div>
-            </div>
-          </header>
-          <div className="api-key-panel-body">
-            <div className="setup-guide-section">
-              <h3 className="setup-guide-heading">How does it work?</h3>
-              <p className="setup-guide-text">
-                MarkMind uses Google's free AI to read your bookmarks and sort them into the right folders.
-              </p>
-              <p className="setup-guide-text">
-                To connect, you need a special password called an API key.
-                Think of it like a Wi-Fi password that connects MarkMind to Google's AI.
-              </p>
-            </div>
-
-            <div className="info-card">
-              <div className="info-card-header">
-                <div className="info-card-icon-wrap">
-                  <CheckCircleIcon width={16} height={16} />
-                </div>
-                <div className="info-card-titles">
-                  <h3 className="info-card-title">Good to know</h3>
-                </div>
-              </div>
-              <div className="setup-guide-reassurances">
-                <p className="setup-guide-reassurance-item">100% free. No credit card needed.</p>
-                <p className="setup-guide-reassurance-item">Your data never leaves your device.</p>
-                <p className="setup-guide-reassurance-item">Takes about 30 seconds to set up.</p>
-              </div>
-            </div>
-
-            <div className="api-key-card">
-              <div className="api-key-card-header">
-                <div className="api-key-icon">
-                  <KeyIcon />
-                </div>
-                <div className="api-key-titles">
-                  <h3 className="api-key-title">How to get your free key</h3>
-                  <p className="api-key-subtitle">Follow these 4 simple steps</p>
-                </div>
-              </div>
-
-              <div className="step-list">
-                <div className="step-list-row">
-                  <span className="step-list-number">1</span>
-                  <span className="step-list-text">
-                    Open Google AI Studio
-                    {' '}
-                    <Button variant="ghost" compact onClick={handleOpenAIStudio}>
-                      <ExternalLinkIcon width={10} height={10} />
-                      Open
-                    </Button>
-                  </span>
-                </div>
-                <div className="step-list-row">
-                  <span className="step-list-number">2</span>
-                  <span className="step-list-text">Sign in with your Google account</span>
-                </div>
-                <div className="step-list-row">
-                  <span className="step-list-number">3</span>
-                  <span className="step-list-text">Click "Create API Key"</span>
-                </div>
-                <div className="step-list-row">
-                  <span className="step-list-number">4</span>
-                  <span className="step-list-text">Copy the key and paste it in Settings</span>
-                </div>
-              </div>
-            </div>
-
-            <Button variant="primary" fullWidth onClick={handleCloseSetupGuide}>
-              Got it
-            </Button>
-          </div>
-        </div>
-      </div>
+      <SetupGuide
+        onClose={handleCloseSetupGuide}
+        onOpenAIStudio={handleOpenAIStudio}
+      />
     );
   }
 

--- a/src/components/ApiKeyPanel/ApiKeyPanel.tsx
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import ServiceSelector from '../ServiceSelector/ServiceSelector';
 import Button from '../Button/Button';
 import { useApiKeyPanel } from '../../hooks/apiKeyPanel';
@@ -10,6 +10,7 @@ import {
   ShieldIcon,
   CheckCircleIcon,
   InfoIcon,
+  ExternalLinkIcon,
   SunIcon,
   MoonIcon,
 } from '../icons/Icons';
@@ -56,6 +57,19 @@ const ApiKeyPanel = ({
   } = useApiKeyPanel({ isOpen, canClose, onClose });
 
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+  const [showSetupGuide, setShowSetupGuide] = useState(false);
+
+  const handleOpenSetupGuide = useCallback((): void => {
+    setShowSetupGuide(true);
+  }, []);
+
+  const handleCloseSetupGuide = useCallback((): void => {
+    setShowSetupGuide(false);
+  }, []);
+
+  const handleOpenAIStudio = useCallback((): void => {
+    chrome.tabs.create({ url: 'https://aistudio.google.com/apikey' });
+  }, []);
 
   if (!isOpen) return null;
 
@@ -63,6 +77,95 @@ const ApiKeyPanel = ({
   const hasModelSelected = selectedModel !== '';
   const isApiKeyInteractive = hasProviderSelected || hasExistingKey;
   const showConfiguredState = hasExistingKey && !isEditingKey && hasModelSelected;
+
+  if (showSetupGuide) {
+    return (
+      <div className="api-key-panel active">
+        <div className="api-key-panel-content">
+          <header className="api-key-panel-header">
+            <div className="header-settings">
+              <div className="header-left">
+                <Button variant="icon" onClick={handleCloseSetupGuide} title="Back to Settings">
+                  <ArrowLeftIcon />
+                </Button>
+                <h2 className="header-title">Setup Guide</h2>
+              </div>
+            </div>
+          </header>
+          <div className="api-key-panel-body">
+            <div className="setup-guide-section">
+              <h3 className="setup-guide-heading">How does it work?</h3>
+              <p className="setup-guide-text">
+                MarkMind uses Google's free AI to read your bookmarks and sort them into the right folders.
+              </p>
+              <p className="setup-guide-text">
+                To connect, you need a special password called an API key.
+                Think of it like a Wi-Fi password that connects MarkMind to Google's AI.
+              </p>
+            </div>
+
+            <div className="info-card">
+              <div className="info-card-header">
+                <div className="info-card-icon-wrap">
+                  <CheckCircleIcon width={16} height={16} />
+                </div>
+                <div className="info-card-titles">
+                  <h3 className="info-card-title">Good to know</h3>
+                </div>
+              </div>
+              <div className="setup-guide-reassurances">
+                <p className="setup-guide-reassurance-item">100% free. No credit card needed.</p>
+                <p className="setup-guide-reassurance-item">Your data never leaves your device.</p>
+                <p className="setup-guide-reassurance-item">Takes about 30 seconds to set up.</p>
+              </div>
+            </div>
+
+            <div className="api-key-card">
+              <div className="api-key-card-header">
+                <div className="api-key-icon">
+                  <KeyIcon />
+                </div>
+                <div className="api-key-titles">
+                  <h3 className="api-key-title">How to get your free key</h3>
+                  <p className="api-key-subtitle">Follow these 4 simple steps</p>
+                </div>
+              </div>
+
+              <div className="step-list">
+                <div className="step-list-row">
+                  <span className="step-list-number">1</span>
+                  <span className="step-list-text">
+                    Open Google AI Studio
+                    {' '}
+                    <Button variant="ghost" compact onClick={handleOpenAIStudio}>
+                      <ExternalLinkIcon width={10} height={10} />
+                      Open
+                    </Button>
+                  </span>
+                </div>
+                <div className="step-list-row">
+                  <span className="step-list-number">2</span>
+                  <span className="step-list-text">Sign in with your Google account</span>
+                </div>
+                <div className="step-list-row">
+                  <span className="step-list-number">3</span>
+                  <span className="step-list-text">Click "Create API Key"</span>
+                </div>
+                <div className="step-list-row">
+                  <span className="step-list-number">4</span>
+                  <span className="step-list-text">Copy the key and paste it in Settings</span>
+                </div>
+              </div>
+            </div>
+
+            <Button variant="primary" fullWidth onClick={handleCloseSetupGuide}>
+              Got it
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="api-key-panel active">
@@ -108,6 +211,14 @@ const ApiKeyPanel = ({
                   <ArrowLeftIcon />
                 </Button>
                 <h2 className="header-title">Settings</h2>
+              </div>
+              <div className="header-right">
+                <div className="header-guide-link">
+                  <Button variant="icon" onClick={handleOpenSetupGuide} title="Setup Guide">
+                    <InfoIcon />
+                  </Button>
+                  <span className="header-guide-tooltip">Setup Guide</span>
+                </div>
               </div>
             </div>
           )}

--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -11,25 +11,63 @@ interface MainContentProps {
   onOpenSettings: () => void;
   theme: ResolvedTheme;
   onToggleTheme: () => void;
+  showOnboardingTooltips?: boolean;
+  onTooltipsDismissed?: () => void;
 }
 
-const MainContent = ({ onOpenSettings, theme, onToggleTheme }: MainContentProps) => {
+const MainContent = ({
+  onOpenSettings,
+  theme,
+  onToggleTheme,
+  showOnboardingTooltips = false,
+  onTooltipsDismissed,
+}: MainContentProps) => {
   const [activeTab, setActiveTab] = useState('home');
+  const [tooltipStep, setTooltipStep] = useState<'card' | 'organize' | 'done'>(
+    showOnboardingTooltips ? 'card' : 'done'
+  );
 
   const handleTabChange = useCallback((tabId: string): void => {
+    if (tooltipStep !== 'done') {
+      setTooltipStep('done');
+      onTooltipsDismissed?.();
+    }
     setActiveTab(tabId);
+  }, [tooltipStep, onTooltipsDismissed]);
+
+  const handleDismissCardTooltip = useCallback((): void => {
+    setTooltipStep('organize');
   }, []);
+
+  const handleDismissOrganizeTooltip = useCallback((): void => {
+    setTooltipStep('done');
+    onTooltipsDismissed?.();
+  }, [onTooltipsDismissed]);
 
   const renderActiveTab = () => {
     switch (activeTab) {
       case 'home':
-        return <HomeTab onTabChange={handleTabChange} onOpenSettings={onOpenSettings} />;
+        return (
+          <HomeTab
+            onTabChange={handleTabChange}
+            onOpenSettings={onOpenSettings}
+            showCardTooltip={tooltipStep === 'card'}
+            onDismissCardTooltip={handleDismissCardTooltip}
+          />
+        );
       case 'organize':
         return <OrganizeTab />;
       case 'discover':
         return <DiscoverTab />;
       default:
-        return <HomeTab onTabChange={handleTabChange} onOpenSettings={onOpenSettings} />;
+        return (
+          <HomeTab
+            onTabChange={handleTabChange}
+            onOpenSettings={onOpenSettings}
+            showCardTooltip={tooltipStep === 'card'}
+            onDismissCardTooltip={handleDismissCardTooltip}
+          />
+        );
     }
   };
 
@@ -58,7 +96,12 @@ const MainContent = ({ onOpenSettings, theme, onToggleTheme }: MainContentProps)
         </div>
       </header>
 
-      <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} />
+      <TabNavigation
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        showOrganizeTooltip={tooltipStep === 'organize'}
+        onDismissOrganizeTooltip={handleDismissOrganizeTooltip}
+      />
 
       <main className="main-content">
         {renderActiveTab()}

--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -46,19 +46,11 @@ const MainContent = ({
 
   const renderActiveTab = () => {
     switch (activeTab) {
-      case 'home':
-        return (
-          <HomeTab
-            onTabChange={handleTabChange}
-            onOpenSettings={onOpenSettings}
-            showCardTooltip={tooltipStep === 'card'}
-            onDismissCardTooltip={handleDismissCardTooltip}
-          />
-        );
       case 'organize':
         return <OrganizeTab />;
       case 'discover':
         return <DiscoverTab />;
+      case 'home':
       default:
         return (
           <HomeTab

--- a/src/components/Onboarding/Onboarding.css
+++ b/src/components/Onboarding/Onboarding.css
@@ -1,0 +1,226 @@
+/**
+ * Onboarding Component Styles
+ * Reuses ApiKeyPanel layout patterns and design tokens
+ */
+
+/* Step Progress Dots */
+.onboarding-progress {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xl) 0;
+}
+
+.onboarding-dot {
+  width: var(--spacing-md);
+  height: var(--spacing-md);
+  border-radius: var(--radius-full);
+  background-color: var(--color-border-light);
+  transition: background-color var(--transition-smooth);
+  border: none;
+  padding: 0;
+}
+
+.onboarding-dot.active {
+  background-color: var(--color-primary);
+}
+
+/* Step Container */
+.onboarding-step {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: var(--spacing-xl);
+}
+
+/* Welcome Step */
+.onboarding-welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--spacing-4xl) 0;
+  gap: var(--spacing-xl);
+}
+
+.onboarding-welcome-logo {
+  width: 48px;
+  height: 48px;
+}
+
+.onboarding-welcome-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-tight);
+  margin: 0;
+}
+
+.onboarding-welcome-subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+  max-width: 280px;
+}
+
+.onboarding-features {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-md) 0;
+}
+
+.onboarding-feature-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.onboarding-feature-item svg {
+  flex-shrink: 0;
+  color: var(--color-primary);
+}
+
+/* Back Button Row */
+.onboarding-back-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--spacing-xs);
+}
+
+/* Explain Step */
+.onboarding-explain-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.onboarding-explain-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+}
+
+.onboarding-reassurances {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.onboarding-reassurance-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.onboarding-reassurance-item svg {
+  flex-shrink: 0;
+}
+
+.onboarding-escape-link {
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-light);
+  text-align: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family);
+  padding: var(--spacing-sm) 0;
+  transition: color var(--transition-fast);
+  width: 100%;
+}
+
+.onboarding-escape-link:hover {
+  color: var(--color-text-muted);
+  text-decoration: underline;
+}
+
+/* Guide Step */
+.onboarding-guide-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.onboarding-guide-subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.onboarding-step-link {
+  display: inline;
+}
+
+/* Input Section */
+.onboarding-input-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding-top: var(--spacing-md);
+}
+
+.onboarding-error-message {
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+  line-height: var(--line-height-normal);
+  margin: 0;
+}
+
+.onboarding-validating-text {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin: 0;
+}
+
+/* Success Step */
+.onboarding-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--spacing-4xl) 0;
+  gap: var(--spacing-xl);
+}
+
+.onboarding-success-icon {
+  color: var(--color-success);
+}
+
+.onboarding-success-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-tight);
+  margin: 0;
+}
+
+.onboarding-success-subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+  max-width: 280px;
+}
+
+/* Button wrapper for full-width at bottom */
+.onboarding-cta {
+  padding-top: var(--spacing-md);
+}

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -108,11 +108,12 @@ const Onboarding = ({
       {renderBackButton()}
       <h2 className="onboarding-explain-title">How does it work?</h2>
       <p className="onboarding-explain-text">
-        MarkMind uses Google's free AI to read your bookmarks and sort them into the right folders.
+        MarkMind uses AI to read your bookmarks and sort them into the right folders.
+        We recommend starting with Google Gemini because it's completely free.
       </p>
       <p className="onboarding-explain-text">
         To connect, you need a special password called an API key.
-        Think of it like a Wi-Fi password that connects MarkMind to Google's AI.
+        Think of it like a Wi-Fi password that lets MarkMind talk to the AI.
       </p>
       <div className="onboarding-reassurances">
         <div className="onboarding-reassurance-item">

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -1,0 +1,271 @@
+import Button from '../Button/Button';
+import {
+  SparklesIcon,
+  ShieldIcon,
+  CheckCircleIcon,
+  ArrowLeftIcon,
+  KeyIcon,
+  ExternalLinkIcon,
+  SpinnerIcon,
+  SunIcon,
+  MoonIcon,
+} from '../icons/Icons';
+import { useOnboarding } from '../../hooks/useOnboarding';
+import { type ResolvedTheme } from '../../hooks/useTheme';
+import { type OnboardingStep } from '../../types/onboarding';
+import { ONBOARDING_STEPS } from '../../config/onboarding';
+import './Onboarding.css';
+
+interface OnboardingProps {
+  isOpen: boolean;
+  onComplete: () => void;
+  onEscapeToApiKeyPanel: () => void;
+  theme: ResolvedTheme;
+  onToggleTheme: () => void;
+  startAtStep?: OnboardingStep;
+}
+
+const Onboarding = ({
+  isOpen,
+  onComplete,
+  onEscapeToApiKeyPanel,
+  theme,
+  onToggleTheme,
+  startAtStep,
+}: OnboardingProps) => {
+  const {
+    currentStep,
+    stepIndex,
+    apiKeyInput,
+    isValidating,
+    errorMessage,
+    handleNext,
+    handleBack,
+    handleApiKeyInputChange,
+    handleApiKeyInputKeyDown,
+    handleApiKeySubmit,
+    handleOpenAIStudio,
+    handleEscape,
+  } = useOnboarding({ onComplete, onEscapeToApiKeyPanel, startAtStep });
+
+  if (!isOpen) return null;
+
+  const renderProgressDots = () => (
+    <div className="onboarding-progress">
+      {ONBOARDING_STEPS.map((step, index) => (
+        <div
+          key={step}
+          className={`onboarding-dot${index <= stepIndex ? ' active' : ''}`}
+        />
+      ))}
+    </div>
+  );
+
+  const renderBackButton = () => (
+    <div className="onboarding-back-row">
+      <Button variant="icon" onClick={handleBack} title="Go back">
+        <ArrowLeftIcon />
+      </Button>
+    </div>
+  );
+
+  const renderWelcomeStep = () => (
+    <div className="onboarding-welcome">
+      <img
+        src="/assets/icons/icon48.png"
+        alt="MarkMind"
+        className="onboarding-welcome-logo"
+      />
+      <h1 className="onboarding-welcome-title">Welcome to MarkMind</h1>
+      <p className="onboarding-welcome-subtitle">
+        Your bookmarks are about to get organized.
+        Automatically. By AI. For free.
+      </p>
+      <div className="onboarding-features">
+        <div className="onboarding-feature-item">
+          <SparklesIcon width={16} height={16} />
+          <span>Smart folders, zero effort</span>
+        </div>
+        <div className="onboarding-feature-item">
+          <ShieldIcon width={16} height={16} />
+          <span>Your data stays on your device</span>
+        </div>
+        <div className="onboarding-feature-item">
+          <CheckCircleIcon width={16} height={16} />
+          <span>Completely free, no credit card</span>
+        </div>
+      </div>
+      <div className="onboarding-cta">
+        <Button variant="primary" fullWidth onClick={handleNext}>
+          Let's get started
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderExplainStep = () => (
+    <div className="onboarding-step">
+      {renderBackButton()}
+      <h2 className="onboarding-explain-title">How does it work?</h2>
+      <p className="onboarding-explain-text">
+        MarkMind uses Google's free AI to read your bookmarks and sort them into the right folders.
+      </p>
+      <p className="onboarding-explain-text">
+        To connect, you need a special password called an API key.
+        Think of it like a Wi-Fi password that connects MarkMind to Google's AI.
+      </p>
+      <div className="onboarding-reassurances">
+        <div className="onboarding-reassurance-item">
+          <CheckCircleIcon width={16} height={16} />
+          <span>100% free. No credit card needed.</span>
+        </div>
+        <div className="onboarding-reassurance-item">
+          <ShieldIcon width={16} height={16} />
+          <span>Your data never leaves your device.</span>
+        </div>
+        <div className="onboarding-reassurance-item">
+          <KeyIcon width={16} height={16} />
+          <span>Takes about 30 seconds to set up.</span>
+        </div>
+      </div>
+      <div className="onboarding-cta">
+        <Button variant="primary" fullWidth onClick={handleNext}>
+          Show me how
+        </Button>
+      </div>
+      <Button
+        variant="unstyled"
+        className="onboarding-escape-link"
+        onClick={handleEscape}
+      >
+        Already have an API key from another provider?
+      </Button>
+    </div>
+  );
+
+  const renderGuideStep = () => (
+    <div className="onboarding-step">
+      {renderBackButton()}
+      <h2 className="onboarding-guide-title">Let's grab your free key</h2>
+      <p className="onboarding-guide-subtitle">Follow these 4 simple steps:</p>
+      <div className="step-list">
+        <div className="step-list-row">
+          <span className="step-list-number">1</span>
+          <span className="step-list-text">
+            Open Google AI Studio
+            <span className="onboarding-step-link">
+              {' '}
+              <Button variant="ghost" compact onClick={handleOpenAIStudio}>
+                <ExternalLinkIcon width={10} height={10} />
+                Open
+              </Button>
+            </span>
+          </span>
+        </div>
+        <div className="step-list-row">
+          <span className="step-list-number">2</span>
+          <span className="step-list-text">Sign in with your Google account</span>
+        </div>
+        <div className="step-list-row">
+          <span className="step-list-number">3</span>
+          <span className="step-list-text">Click "Create API Key"</span>
+        </div>
+        <div className="step-list-row">
+          <span className="step-list-number">4</span>
+          <span className="step-list-text">Copy the key and paste it below</span>
+        </div>
+      </div>
+      <div className="onboarding-input-section">
+        <input
+          type="password"
+          placeholder="Paste your key here"
+          value={apiKeyInput}
+          onChange={handleApiKeyInputChange}
+          onKeyDown={handleApiKeyInputKeyDown}
+          disabled={isValidating}
+        />
+        {errorMessage && (
+          <p className="onboarding-error-message">{errorMessage}</p>
+        )}
+        {isValidating && (
+          <p className="onboarding-validating-text">
+            <SpinnerIcon width={12} height={12} />
+            Connecting...
+          </p>
+        )}
+        <Button
+          variant="primary"
+          fullWidth
+          onClick={handleApiKeySubmit}
+          disabled={isValidating}
+        >
+          {isValidating ? 'Connecting...' : 'Connect to Google AI'}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderSuccessStep = () => (
+    <div className="onboarding-success">
+      <CheckCircleIcon width={48} height={48} className="onboarding-success-icon" />
+      <h2 className="onboarding-success-title">You're all set!</h2>
+      <p className="onboarding-success-subtitle">
+        MarkMind is connected and ready to organize your bookmarks.
+      </p>
+      <div className="onboarding-cta">
+        <Button variant="primary" fullWidth onClick={handleNext}>
+          Start organizing
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderCurrentStep = () => {
+    switch (currentStep) {
+      case 'welcome':
+        return renderWelcomeStep();
+      case 'explain':
+        return renderExplainStep();
+      case 'guide':
+        return renderGuideStep();
+      case 'success':
+        return renderSuccessStep();
+      default:
+        return renderWelcomeStep();
+    }
+  };
+
+  return (
+    <div className="api-key-panel active">
+      <div className="api-key-panel-content">
+        <header className="api-key-panel-header">
+          <div className="header-welcome">
+            <div className="header-left">
+              <img
+                src="/assets/icons/icon48.png"
+                alt="MarkMind"
+                className="header-logo"
+              />
+              <h1 className="header-title">MarkMind</h1>
+            </div>
+            <div className="header-right">
+              <Button
+                variant="icon"
+                onClick={onToggleTheme}
+                title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+              </Button>
+            </div>
+          </div>
+        </header>
+        <div className="api-key-panel-body">
+          {renderProgressDots()}
+          {renderCurrentStep()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Onboarding;

--- a/src/components/OnboardingTooltip/OnboardingTooltip.css
+++ b/src/components/OnboardingTooltip/OnboardingTooltip.css
@@ -1,0 +1,60 @@
+/**
+ * OnboardingTooltip Component Styles
+ * Reuses info-card pattern with arrow pointer
+ */
+
+.onboarding-tooltip {
+  position: relative;
+  background-color: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xl);
+  box-shadow: var(--shadow-md);
+  max-width: 280px;
+  z-index: 50;
+  animation: onboarding-tooltip-in 200ms ease-out;
+}
+
+@keyframes onboarding-tooltip-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.onboarding-tooltip::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: var(--spacing-2xl);
+  width: 10px;
+  height: 10px;
+  background-color: var(--color-white);
+  border-left: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
+  transform: rotate(45deg);
+}
+
+.onboarding-tooltip-content {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+}
+
+.onboarding-tooltip-text {
+  flex: 1;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+}
+
+.onboarding-tooltip-dismiss {
+  flex-shrink: 0;
+  margin-top: calc(-1 * var(--spacing-xs));
+  margin-right: calc(-1 * var(--spacing-xs));
+}

--- a/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -1,0 +1,28 @@
+import Button from '../Button/Button';
+import { XIcon } from '../icons/Icons';
+import './OnboardingTooltip.css';
+
+interface OnboardingTooltipProps {
+  content: string;
+  onDismiss: () => void;
+}
+
+const OnboardingTooltip = ({ content, onDismiss }: OnboardingTooltipProps) => {
+  return (
+    <div className="onboarding-tooltip">
+      <div className="onboarding-tooltip-content">
+        <p className="onboarding-tooltip-text">{content}</p>
+        <Button
+          variant="icon"
+          className="onboarding-tooltip-dismiss"
+          onClick={onDismiss}
+          title="Dismiss"
+        >
+          <XIcon width={12} height={12} />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OnboardingTooltip;

--- a/src/components/SetupGuide/SetupGuide.css
+++ b/src/components/SetupGuide/SetupGuide.css
@@ -1,0 +1,37 @@
+/**
+ * SetupGuide Component Styles
+ * Reuses api-key-panel layout, info-card, and step-list-* from index.css
+ */
+
+.setup-guide-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.setup-guide-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.setup-guide-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+}
+
+.setup-guide-reassurances {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.setup-guide-reassurance-item {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+  padding: var(--spacing-2xs) 0;
+}

--- a/src/components/SetupGuide/SetupGuide.tsx
+++ b/src/components/SetupGuide/SetupGuide.tsx
@@ -29,11 +29,12 @@ const SetupGuide = ({ onClose, onOpenAIStudio }: SetupGuideProps) => (
         <div className="setup-guide-section">
           <h3 className="setup-guide-heading">How does it work?</h3>
           <p className="setup-guide-text">
-            MarkMind uses Google's free AI to read your bookmarks and sort them into the right folders.
+            MarkMind uses AI to read your bookmarks and sort them into the right folders.
+            We recommend starting with Google Gemini because it's completely free.
           </p>
           <p className="setup-guide-text">
             To connect, you need a special password called an API key.
-            Think of it like a Wi-Fi password that connects MarkMind to Google's AI.
+            Think of it like a Wi-Fi password that lets MarkMind talk to the AI.
           </p>
         </div>
 

--- a/src/components/SetupGuide/SetupGuide.tsx
+++ b/src/components/SetupGuide/SetupGuide.tsx
@@ -1,0 +1,102 @@
+import Button from '../Button/Button';
+import {
+  ArrowLeftIcon,
+  KeyIcon,
+  CheckCircleIcon,
+  ExternalLinkIcon,
+} from '../icons/Icons';
+import './SetupGuide.css';
+
+interface SetupGuideProps {
+  onClose: () => void;
+  onOpenAIStudio: () => void;
+}
+
+const SetupGuide = ({ onClose, onOpenAIStudio }: SetupGuideProps) => (
+  <div className="api-key-panel active">
+    <div className="api-key-panel-content">
+      <header className="api-key-panel-header">
+        <div className="header-settings">
+          <div className="header-left">
+            <Button variant="icon" onClick={onClose} title="Back to Settings">
+              <ArrowLeftIcon />
+            </Button>
+            <h2 className="header-title">Setup Guide</h2>
+          </div>
+        </div>
+      </header>
+      <div className="api-key-panel-body">
+        <div className="setup-guide-section">
+          <h3 className="setup-guide-heading">How does it work?</h3>
+          <p className="setup-guide-text">
+            MarkMind uses Google's free AI to read your bookmarks and sort them into the right folders.
+          </p>
+          <p className="setup-guide-text">
+            To connect, you need a special password called an API key.
+            Think of it like a Wi-Fi password that connects MarkMind to Google's AI.
+          </p>
+        </div>
+
+        <div className="info-card">
+          <div className="info-card-header">
+            <div className="info-card-icon-wrap">
+              <CheckCircleIcon width={16} height={16} />
+            </div>
+            <div className="info-card-titles">
+              <h3 className="info-card-title">Good to know</h3>
+            </div>
+          </div>
+          <div className="setup-guide-reassurances">
+            <p className="setup-guide-reassurance-item">100% free. No credit card needed.</p>
+            <p className="setup-guide-reassurance-item">Your data never leaves your device.</p>
+            <p className="setup-guide-reassurance-item">Takes about 30 seconds to set up.</p>
+          </div>
+        </div>
+
+        <div className="api-key-card">
+          <div className="api-key-card-header">
+            <div className="api-key-icon">
+              <KeyIcon />
+            </div>
+            <div className="api-key-titles">
+              <h3 className="api-key-title">How to get your free key</h3>
+              <p className="api-key-subtitle">Follow these 4 simple steps</p>
+            </div>
+          </div>
+
+          <div className="step-list">
+            <div className="step-list-row">
+              <span className="step-list-number">1</span>
+              <span className="step-list-text">
+                Open Google AI Studio
+                {' '}
+                <Button variant="ghost" compact onClick={onOpenAIStudio}>
+                  <ExternalLinkIcon width={10} height={10} />
+                  Open
+                </Button>
+              </span>
+            </div>
+            <div className="step-list-row">
+              <span className="step-list-number">2</span>
+              <span className="step-list-text">Sign in with your Google account</span>
+            </div>
+            <div className="step-list-row">
+              <span className="step-list-number">3</span>
+              <span className="step-list-text">Click "Create API Key"</span>
+            </div>
+            <div className="step-list-row">
+              <span className="step-list-number">4</span>
+              <span className="step-list-text">Copy the key and paste it in Settings</span>
+            </div>
+          </div>
+        </div>
+
+        <Button variant="primary" fullWidth onClick={onClose}>
+          Got it
+        </Button>
+      </div>
+    </div>
+  </div>
+);
+
+export default SetupGuide;

--- a/src/components/TabNavigation/TabNavigation.css
+++ b/src/components/TabNavigation/TabNavigation.css
@@ -1,3 +1,7 @@
+.tab-navigation-wrapper {
+  position: relative;
+}
+
 .tab-navigation {
   display: flex;
   gap: var(--spacing-sm);
@@ -12,4 +16,12 @@
   padding: var(--spacing-md) var(--spacing-md);
   font-size: var(--font-size-xs);
   gap: var(--spacing-xs);
+}
+
+.tab-navigation-tooltip {
+  position: absolute;
+  top: 100%;
+  left: 25%;
+  padding-top: var(--spacing-md);
+  z-index: 50;
 }

--- a/src/components/TabNavigation/TabNavigation.tsx
+++ b/src/components/TabNavigation/TabNavigation.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { HomeIcon, FolderIcon, CompassIcon, BookOpenIcon, ExternalLinkIcon } from '../icons/Icons';
 import Button from '../Button/Button';
+import OnboardingTooltip from '../OnboardingTooltip/OnboardingTooltip';
 import { MARKMIND_BLOG_URL } from '../../config/discoverContent';
 import './TabNavigation.css';
 
@@ -22,9 +23,16 @@ const TAB_CONFIG: TabConfig[] = [
 interface TabNavigationProps {
   activeTab: string;
   onTabChange: (tabId: string) => void;
+  showOrganizeTooltip?: boolean;
+  onDismissOrganizeTooltip?: () => void;
 }
 
-const TabNavigation = ({ activeTab, onTabChange }: TabNavigationProps) => {
+const TabNavigation = ({
+  activeTab,
+  onTabChange,
+  showOrganizeTooltip = false,
+  onDismissOrganizeTooltip,
+}: TabNavigationProps) => {
   const handleTabClick = useCallback(
     (tabConfig: TabConfig) => () => {
       if (tabConfig.isExternal && tabConfig.url) {
@@ -37,24 +45,34 @@ const TabNavigation = ({ activeTab, onTabChange }: TabNavigationProps) => {
   );
 
   return (
-    <nav className="tab-navigation">
-      {TAB_CONFIG.map((tabConfig) => {
-        const TabIcon = tabConfig.icon;
-        return (
-          <Button
-            key={tabConfig.id}
-            variant="ghost"
-            active={!tabConfig.isExternal && activeTab === tabConfig.id}
-            onClick={handleTabClick(tabConfig)}
-            className="tab-navigation-button"
-          >
-            <TabIcon width={12} height={12} />
-            {tabConfig.label}
-            {tabConfig.isExternal && <ExternalLinkIcon width={8} height={8} />}
-          </Button>
-        );
-      })}
-    </nav>
+    <div className="tab-navigation-wrapper">
+      <nav className="tab-navigation">
+        {TAB_CONFIG.map((tabConfig) => {
+          const TabIcon = tabConfig.icon;
+          return (
+            <Button
+              key={tabConfig.id}
+              variant="ghost"
+              active={!tabConfig.isExternal && activeTab === tabConfig.id}
+              onClick={handleTabClick(tabConfig)}
+              className="tab-navigation-button"
+            >
+              <TabIcon width={12} height={12} />
+              {tabConfig.label}
+              {tabConfig.isExternal && <ExternalLinkIcon width={8} height={8} />}
+            </Button>
+          );
+        })}
+      </nav>
+      {showOrganizeTooltip && onDismissOrganizeTooltip && (
+        <div className="tab-navigation-tooltip">
+          <OnboardingTooltip
+            content="Got messy bookmarks? This is where the magic happens."
+            onDismiss={onDismissOrganizeTooltip}
+          />
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/icons/Icons.tsx
+++ b/src/components/icons/Icons.tsx
@@ -44,8 +44,8 @@ export const ArrowRightIcon = ({ width = 14, height = 14 }: IconProps) => (
   </svg>
 );
 
-export const KeyIcon = () => (
-  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+export const KeyIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width={width} height={height}>
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -55,8 +55,8 @@ export const KeyIcon = () => (
   </svg>
 );
 
-export const ShieldIcon = () => (
-  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+export const ShieldIcon = ({ width = 14, height = 14 }: IconProps) => (
+  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width={width} height={height}>
     <path
       strokeLinecap="round"
       strokeLinejoin="round"

--- a/src/components/tabs/HomeTab.tsx
+++ b/src/components/tabs/HomeTab.tsx
@@ -2,13 +2,21 @@ import { useOrganizeBookmark } from '../../hooks/useOrganizeBookmark';
 import WelcomeBanner from '../WelcomeBanner/WelcomeBanner';
 import CurrentPageCard from '../CurrentPageCard/CurrentPageCard';
 import QuickActions from '../QuickActions/QuickActions';
+import OnboardingTooltip from '../OnboardingTooltip/OnboardingTooltip';
 
 interface HomeTabProps {
   onTabChange: (tabId: string) => void;
   onOpenSettings: () => void;
+  showCardTooltip?: boolean;
+  onDismissCardTooltip?: () => void;
 }
 
-const HomeTab = ({ onTabChange, onOpenSettings }: HomeTabProps) => {
+const HomeTab = ({
+  onTabChange,
+  onOpenSettings,
+  showCardTooltip = false,
+  onDismissCardTooltip,
+}: HomeTabProps) => {
   const {
     currentPageData,
     isLoadingPage,
@@ -39,6 +47,12 @@ const HomeTab = ({ onTabChange, onOpenSettings }: HomeTabProps) => {
         onAccept={handleAcceptSuggestion}
         onDecline={handleDeclineSuggestion}
       />
+      {showCardTooltip && onDismissCardTooltip && (
+        <OnboardingTooltip
+          content="This shows the page you're on. Hit Organize to find the perfect folder!"
+          onDismiss={onDismissCardTooltip}
+        />
+      )}
       <QuickActions onTabChange={onTabChange} onOpenSettings={onOpenSettings} />
     </>
   );

--- a/src/config/onboarding.ts
+++ b/src/config/onboarding.ts
@@ -11,3 +11,5 @@ export const ONBOARDING_STEP_STORAGE_KEY = 'onboardingStep';
 export const ONBOARDING_COMPLETE_STORAGE_KEY = 'onboardingComplete';
 export const ONBOARDING_TOOLTIPS_PENDING_KEY = 'showOnboardingTooltips';
 export const ONBOARDING_TOOLTIPS_SEEN_KEY = 'onboardingTooltipsSeen';
+
+export const AI_STUDIO_URL = 'https://aistudio.google.com/apikey';

--- a/src/config/onboarding.ts
+++ b/src/config/onboarding.ts
@@ -1,0 +1,13 @@
+import { type OnboardingStep } from '../types/onboarding';
+
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+  'welcome',
+  'explain',
+  'guide',
+  'success',
+];
+
+export const ONBOARDING_STEP_STORAGE_KEY = 'onboardingStep';
+export const ONBOARDING_COMPLETE_STORAGE_KEY = 'onboardingComplete';
+export const ONBOARDING_TOOLTIPS_PENDING_KEY = 'showOnboardingTooltips';
+export const ONBOARDING_TOOLTIPS_SEEN_KEY = 'onboardingTooltipsSeen';

--- a/src/hooks/useOnboarding/handlers/handleOnboardingKeySave.ts
+++ b/src/hooks/useOnboarding/handlers/handleOnboardingKeySave.ts
@@ -1,0 +1,72 @@
+import { SERVICES, MODELS_CACHE_KEY_PREFIX, SELECTED_SERVICE_STORAGE_KEY, SELECTED_MODEL_STORAGE_KEY } from '../../../config/services';
+import { fetchModelsForProvider } from '../../../services/ai/providerUtils';
+import { setSelectedServiceId, setSelectedModelId } from '../../../services/selectedState';
+import { type HandleOnboardingKeySaveDeps } from '../types';
+
+export const createHandleOnboardingKeySave = (deps: HandleOnboardingKeySaveDeps) => {
+  return async (): Promise<void> => {
+    const { apiKeyInput, setIsValidating, setErrorMessage, setCurrentStep, persistStep } = deps;
+
+    const trimmedKey = apiKeyInput.trim();
+
+    if (!trimmedKey) {
+      setErrorMessage('Paste your key in the field above first.');
+      return;
+    }
+
+    const geminiService = SERVICES.google;
+
+    if (!geminiService.validateKey(trimmedKey)) {
+      setErrorMessage("Hmm, that doesn't look right. Make sure you copied the whole key from Google AI Studio.");
+      return;
+    }
+
+    setIsValidating(true);
+    setErrorMessage('');
+
+    try {
+      await chrome.storage.local.set({ [geminiService.storageKey]: trimmedKey });
+
+      const models = await fetchModelsForProvider('google', trimmedKey);
+
+      if (models.length === 0) {
+        setErrorMessage('Something went wrong loading AI models. Try again in a moment.');
+        setIsValidating(false);
+        return;
+      }
+
+      const cacheKey = `${MODELS_CACHE_KEY_PREFIX}google`;
+      await chrome.storage.local.set({
+        [cacheKey]: { models, fetchedAt: Date.now() },
+      });
+
+      const firstModel = models[0].id;
+      await chrome.storage.local.set({
+        [SELECTED_SERVICE_STORAGE_KEY]: 'google',
+        [SELECTED_MODEL_STORAGE_KEY]: firstModel,
+        [`selectedModel_google`]: firstModel,
+      });
+
+      setSelectedServiceId('google');
+      setSelectedModelId(firstModel);
+
+      setCurrentStep('success');
+      await persistStep('success');
+
+      setIsValidating(false);
+    } catch (error) {
+      console.error('Failed to validate onboarding API key:', error);
+      const message = error instanceof Error ? error.message.toLowerCase() : '';
+
+      const isAuthError = message.includes('invalid') || message.includes('api key')
+        || message.includes('unauthorized') || message.includes('permission');
+
+      if (isAuthError) {
+        setErrorMessage("That key didn't work. Double-check you copied the full key from Google AI Studio.");
+      } else {
+        setErrorMessage("Something went wrong on our end. Your key might be fine. Try again in a moment.");
+      }
+      setIsValidating(false);
+    }
+  };
+};

--- a/src/hooks/useOnboarding/handlers/handleOnboardingKeySave.ts
+++ b/src/hooks/useOnboarding/handlers/handleOnboardingKeySave.ts
@@ -35,13 +35,11 @@ export const createHandleOnboardingKeySave = (deps: HandleOnboardingKeySaveDeps)
         return;
       }
 
+      const firstModel = models[0].id;
       const cacheKey = `${MODELS_CACHE_KEY_PREFIX}google`;
+
       await chrome.storage.local.set({
         [cacheKey]: { models, fetchedAt: Date.now() },
-      });
-
-      const firstModel = models[0].id;
-      await chrome.storage.local.set({
         [SELECTED_SERVICE_STORAGE_KEY]: 'google',
         [SELECTED_MODEL_STORAGE_KEY]: firstModel,
         [`selectedModel_google`]: firstModel,

--- a/src/hooks/useOnboarding/handlers/index.ts
+++ b/src/hooks/useOnboarding/handlers/index.ts
@@ -1,0 +1,1 @@
+export { createHandleOnboardingKeySave } from './handleOnboardingKeySave';

--- a/src/hooks/useOnboarding/index.ts
+++ b/src/hooks/useOnboarding/index.ts
@@ -1,0 +1,2 @@
+export { useOnboarding } from './useOnboarding';
+export type { UseOnboardingProps, UseOnboardingReturn } from './types';

--- a/src/hooks/useOnboarding/types.ts
+++ b/src/hooks/useOnboarding/types.ts
@@ -1,0 +1,30 @@
+import { type OnboardingStep } from '../../types/onboarding';
+
+export interface UseOnboardingProps {
+  onComplete: () => void;
+  onEscapeToApiKeyPanel: () => void;
+  startAtStep?: OnboardingStep;
+}
+
+export interface UseOnboardingReturn {
+  currentStep: OnboardingStep;
+  stepIndex: number;
+  apiKeyInput: string;
+  isValidating: boolean;
+  errorMessage: string;
+  handleNext: () => void;
+  handleBack: () => void;
+  handleApiKeyInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleApiKeyInputKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  handleApiKeySubmit: () => Promise<void>;
+  handleOpenAIStudio: () => void;
+  handleEscape: () => void;
+}
+
+export interface HandleOnboardingKeySaveDeps {
+  apiKeyInput: string;
+  setIsValidating: (value: boolean) => void;
+  setErrorMessage: (message: string) => void;
+  setCurrentStep: (step: OnboardingStep) => void;
+  persistStep: (step: OnboardingStep) => Promise<void>;
+}

--- a/src/hooks/useOnboarding/useOnboarding.ts
+++ b/src/hooks/useOnboarding/useOnboarding.ts
@@ -5,6 +5,7 @@ import {
   ONBOARDING_STEP_STORAGE_KEY,
   ONBOARDING_COMPLETE_STORAGE_KEY,
   ONBOARDING_TOOLTIPS_PENDING_KEY,
+  AI_STUDIO_URL,
 } from '../../config/onboarding';
 import { type UseOnboardingProps, type UseOnboardingReturn } from './types';
 import { createHandleOnboardingKeySave } from './handlers';
@@ -98,7 +99,7 @@ export const useOnboarding = ({
   );
 
   const handleOpenAIStudio = useCallback((): void => {
-    chrome.tabs.create({ url: 'https://aistudio.google.com/apikey' });
+    chrome.tabs.create({ url: AI_STUDIO_URL });
   }, []);
 
   const handleEscape = useCallback(async (): Promise<void> => {

--- a/src/hooks/useOnboarding/useOnboarding.ts
+++ b/src/hooks/useOnboarding/useOnboarding.ts
@@ -1,0 +1,147 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { type OnboardingStep } from '../../types/onboarding';
+import {
+  ONBOARDING_STEPS,
+  ONBOARDING_STEP_STORAGE_KEY,
+  ONBOARDING_COMPLETE_STORAGE_KEY,
+  ONBOARDING_TOOLTIPS_PENDING_KEY,
+} from '../../config/onboarding';
+import { type UseOnboardingProps, type UseOnboardingReturn } from './types';
+import { createHandleOnboardingKeySave } from './handlers';
+
+export const useOnboarding = ({
+  onComplete,
+  onEscapeToApiKeyPanel,
+  startAtStep,
+}: UseOnboardingProps): UseOnboardingReturn => {
+  const [currentStep, setCurrentStep] = useState<OnboardingStep>(startAtStep || 'welcome');
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (startAtStep) return;
+
+    const loadSavedStep = async (): Promise<void> => {
+      try {
+        const result = await chrome.storage.local.get(ONBOARDING_STEP_STORAGE_KEY);
+        const savedStep = result[ONBOARDING_STEP_STORAGE_KEY] as OnboardingStep | undefined;
+        if (savedStep && ONBOARDING_STEPS.includes(savedStep)) {
+          setCurrentStep(savedStep);
+        }
+      } catch (error) {
+        console.error('Failed to load onboarding step:', error);
+      }
+    };
+
+    loadSavedStep();
+  }, [startAtStep]);
+
+  const stepIndex = ONBOARDING_STEPS.indexOf(currentStep);
+
+  const persistStep = useCallback(async (step: OnboardingStep): Promise<void> => {
+    try {
+      await chrome.storage.local.set({ [ONBOARDING_STEP_STORAGE_KEY]: step });
+    } catch (error) {
+      console.error('Failed to persist onboarding step:', error);
+    }
+  }, []);
+
+  const handleNext = useCallback((): void => {
+    const nextIndex = stepIndex + 1;
+    if (nextIndex < ONBOARDING_STEPS.length) {
+      const nextStep = ONBOARDING_STEPS[nextIndex];
+      setCurrentStep(nextStep);
+      setErrorMessage('');
+      persistStep(nextStep);
+    }
+  }, [stepIndex, persistStep]);
+
+  const handleBack = useCallback((): void => {
+    const prevIndex = stepIndex - 1;
+    if (prevIndex >= 0) {
+      const prevStep = ONBOARDING_STEPS[prevIndex];
+      setCurrentStep(prevStep);
+      setErrorMessage('');
+      persistStep(prevStep);
+    }
+  }, [stepIndex, persistStep]);
+
+  const handleApiKeyInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>): void => {
+      setApiKeyInput(event.target.value);
+      if (errorMessage) {
+        setErrorMessage('');
+      }
+    },
+    [errorMessage]
+  );
+
+  const handleApiKeySubmit = useMemo(
+    () => createHandleOnboardingKeySave({
+      apiKeyInput,
+      setIsValidating,
+      setErrorMessage,
+      setCurrentStep,
+      persistStep,
+    }),
+    [apiKeyInput, persistStep]
+  );
+
+  const handleApiKeyInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === 'Enter') {
+        handleApiKeySubmit();
+      }
+    },
+    [handleApiKeySubmit]
+  );
+
+  const handleOpenAIStudio = useCallback((): void => {
+    chrome.tabs.create({ url: 'https://aistudio.google.com/apikey' });
+  }, []);
+
+  const handleEscape = useCallback(async (): Promise<void> => {
+    try {
+      await chrome.storage.local.set({ [ONBOARDING_COMPLETE_STORAGE_KEY]: true });
+    } catch (error) {
+      console.error('Failed to mark onboarding as complete:', error);
+    }
+    onEscapeToApiKeyPanel();
+  }, [onEscapeToApiKeyPanel]);
+
+  const handleComplete = useCallback(async (): Promise<void> => {
+    try {
+      await chrome.storage.local.set({
+        [ONBOARDING_COMPLETE_STORAGE_KEY]: true,
+        [ONBOARDING_TOOLTIPS_PENDING_KEY]: true,
+      });
+    } catch (error) {
+      console.error('Failed to mark onboarding as complete:', error);
+    }
+    onComplete();
+  }, [onComplete]);
+
+  const wrappedHandleNext = useCallback((): void => {
+    if (currentStep === 'success') {
+      handleComplete();
+    } else {
+      handleNext();
+    }
+  }, [currentStep, handleComplete, handleNext]);
+
+  return {
+    currentStep,
+    stepIndex,
+    apiKeyInput,
+    isValidating,
+    errorMessage,
+    handleNext: wrappedHandleNext,
+    handleBack,
+    handleApiKeyInputChange,
+    handleApiKeyInputKeyDown,
+    handleApiKeySubmit,
+    handleOpenAIStudio,
+    handleEscape,
+  };
+};

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -410,6 +410,43 @@ a:hover {
   font-weight: var(--font-weight-medium);
 }
 
+/* ========================================
+   Numbered Step List (shared across Onboarding + Setup Guide)
+   ======================================== */
+.step-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.step-list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xl);
+  padding: var(--spacing-sm) 0;
+}
+
+.step-list-number {
+  width: var(--spacing-3xl);
+  height: var(--spacing-3xl);
+  border-radius: var(--radius-full);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-bold);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.step-list-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+  flex: 1;
+}
+
 /* Spinner Animation */
 .spinner {
   animation: spin 1s linear infinite;

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,0 +1,1 @@
+export type OnboardingStep = 'welcome' | 'explain' | 'guide' | 'success';


### PR DESCRIPTION
## Summary
- **4-step guided onboarding** for first-time users who don't know what an API key is
- Steers users toward **Google Gemini free tier** (no credit card, no cost) with plain language and zero jargon
- **Post-onboarding mini-tour** with 2 dismissible tooltips highlighting CurrentPageCard and Organize tab
- **Setup guide** accessible via info icon in Settings header for returning users who need a refresher
- Step progress persisted to `chrome.storage.local` so closing the popup resumes where user left off

### Onboarding Steps
1. **Welcome** — Value props (smart folders, free, data stays local)
2. **Explain** — What an API key is in plain language ("like a Wi-Fi password"), with escape hatch for power users
3. **Guide** — 4 numbered steps to get a Gemini key, paste input, validate with friendly error messages
4. **Success** — Celebration, auto-selects first model, transitions to app

### New Files
- `src/types/onboarding.ts` — OnboardingStep type
- `src/config/onboarding.ts` — Storage keys, step definitions
- `src/hooks/useOnboarding/` — Hook with state machine, handler for Gemini key validation
- `src/components/Onboarding/` — 4-step onboarding UI
- `src/components/OnboardingTooltip/` — Dismissible tooltip for mini-tour

### Modified Files
- `src/App.tsx` — Routes first-time users to onboarding vs ApiKeyPanel
- `src/components/ApiKeyPanel/` — Setup guide view, info icon in Settings header
- `src/components/MainContent/` — Tooltip state management
- `src/components/tabs/HomeTab.tsx` — Card tooltip rendering
- `src/components/TabNavigation/` — Organize tooltip rendering
- `src/components/icons/Icons.tsx` — ShieldIcon and KeyIcon now accept width/height props
- `src/styles/index.css` — Shared .step-list-* utility classes

## Test plan
- [ ] Clear extension storage to simulate first-time user, verify onboarding appears
- [ ] Walk through all 4 steps, verify back buttons work on each
- [ ] Close popup mid-onboarding, reopen, verify it resumes at same step
- [ ] Paste a valid Gemini key, verify validation + auto model selection + advance to success
- [ ] Paste an invalid key, verify friendly error message (no jargon)
- [ ] Click "Already have an API key from another provider?" on step 2, verify it goes to ApiKeyPanel
- [ ] After completing onboarding, verify tooltip 1 appears on CurrentPageCard
- [ ] Dismiss tooltip 1, verify tooltip 2 appears on Organize tab
- [ ] Dismiss tooltip 2, verify no tooltips on subsequent opens
- [ ] Existing user with saved key — verify onboarding never appears
- [ ] In Settings, verify info icon shows "Setup Guide" tooltip on hover
- [ ] Click info icon, verify read-only guide appears with "Got it" button
- [ ] Test all screens in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)