### PR TITLE
fix: use dynamic max_tokens from provider APIs instead of hardcoded value

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -22,7 +22,8 @@ const handleStartOrganize = async (payload: StartOrganizePayload): Promise<void>
     payload.modelId,
     payload.bookmarks,
     payload.folderTree,
-    payload.pathToIdMap
+    payload.pathToIdMap,
+    payload.maxOutputTokens
   );
 
   // Merge AI results into the existing session (or a fresh one if storage read fails)

--- a/src/components/ServiceSelector/ServiceSelector.tsx
+++ b/src/components/ServiceSelector/ServiceSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import {
   SERVICES,
   SELECTED_SERVICE_STORAGE_KEY,
@@ -37,6 +37,8 @@ const ServiceSelector = ({
   const [currentServiceId, setCurrentServiceId] = useState<string>('');
   const [currentModelId, setCurrentModelId] = useState<string>('');
   const [availableModels, setAvailableModels] = useState<ModelOption[]>([]);
+  const availableModelsRef = useRef(availableModels);
+  availableModelsRef.current = availableModels;
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [modelsError, setModelsError] = useState('');
 
@@ -86,8 +88,9 @@ const ServiceSelector = ({
   }, []);
 
   const selectModel = useCallback(async (serviceId: string, modelId: string): Promise<void> => {
+    const model = availableModelsRef.current.find((m) => m.id === modelId);
     setCurrentModelId(modelId);
-    setSelectedModelId(modelId);
+    setSelectedModelId(modelId, model?.maxOutputTokens);
     await chrome.storage.local.set({
       [getPerProviderModelKey(serviceId)]: modelId,
       [SELECTED_MODEL_STORAGE_KEY]: modelId,

--- a/src/hooks/useBulkOrganize/useBulkOrganize.ts
+++ b/src/hooks/useBulkOrganize/useBulkOrganize.ts
@@ -7,6 +7,7 @@ import { getBookmarkStats, flattenAllBookmarks } from '../../utils/bookmarkScann
 import { getFolderDataForAI, buildFullIdToPathMapFromTree } from '../../utils/folders';
 import { saveOrganizeSession, loadOrganizeSession, clearOrganizeSession, getInitialSession } from '../../services/organizeSession';
 import { moveBookmark, createFolderPath } from '../../services/bookmarks';
+import { getSelectedMaxOutputTokens } from '../../services/selectedState';
 import { type UseBulkOrganizeReturn } from './types';
 
 const LOADING_MESSAGE_INTERVAL_MS = 2000;
@@ -294,6 +295,7 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
           folderTree: currentSession.folderTree,
           pathToIdMap: currentSession.pathToIdMap,
           defaultParentId: currentSession.defaultParentId,
+          maxOutputTokens: getSelectedMaxOutputTokens(),
         },
       }).catch(async (error) => {
         console.error('Error starting organize:', error);

--- a/src/hooks/useOnboarding/handlers/handleOnboardingKeySave.ts
+++ b/src/hooks/useOnboarding/handlers/handleOnboardingKeySave.ts
@@ -46,7 +46,7 @@ export const createHandleOnboardingKeySave = (deps: HandleOnboardingKeySaveDeps)
       });
 
       setSelectedServiceId('google');
-      setSelectedModelId(firstModel);
+      setSelectedModelId(firstModel, models[0].maxOutputTokens);
 
       setCurrentStep('success');
       await persistStep('success');

--- a/src/services/ai/bulkOrganize.ts
+++ b/src/services/ai/bulkOrganize.ts
@@ -3,11 +3,16 @@ import { type FolderPathMap } from '../../types/bookmarks';
 import { BULK_ORGANIZE_SYSTEM_PROMPT, buildBulkOrganizeUserPrompt } from './bulkPrompt';
 import { getApiKey, callProvider } from './providerUtils';
 import { findFolderIdByAIPath } from '../../utils/folders';
+import { type ModelOption } from '../../types/services';
+import { MODELS_CACHE_KEY_PREFIX } from '../../config/services';
 
-// Gemini 2.5 Flash uses "thinking" tokens that count against maxOutputTokens,
-// so this budget must be high enough for both thinking and the full response.
-// 65536 = Gemini 2.5 Flash max. Other providers cap at their own limits.
-const ORGANIZE_MAX_TOKENS = 65536;
+const lookupMaxOutputTokens = async (serviceId: string, modelId: string): Promise<number | undefined> => {
+  const cacheKey = `${MODELS_CACHE_KEY_PREFIX}${serviceId}`;
+  const cached = await chrome.storage.local.get([cacheKey]);
+  const entry = cached[cacheKey] as { models: ModelOption[] } | undefined;
+  const model = entry?.models?.find((m) => m.id === modelId);
+  return model?.maxOutputTokens;
+};
 
 const extractJsonFromResponse = (responseText: string): string => {
   const trimmed = responseText.trim();
@@ -88,8 +93,10 @@ export const organizeBookmarks = async (
   modelId: string,
   bookmarks: CompactBookmark[],
   folderTree: string,
-  pathToIdMap: FolderPathMap
+  pathToIdMap: FolderPathMap,
+  maxOutputTokens?: number
 ): Promise<BulkOrganizeResult> => {
+  const resolvedTokens = maxOutputTokens ?? await lookupMaxOutputTokens(serviceId, modelId);
   const apiKey = await getApiKey(serviceId);
   const userPrompt = buildBulkOrganizeUserPrompt(bookmarks, folderTree);
 
@@ -99,7 +106,7 @@ export const organizeBookmarks = async (
     BULK_ORGANIZE_SYSTEM_PROMPT,
     userPrompt,
     modelId,
-    ORGANIZE_MAX_TOKENS
+    resolvedTokens
   );
 
   return parseBulkOrganizeResponse(responseText, bookmarks, pathToIdMap);

--- a/src/services/ai/providers/anthropic.ts
+++ b/src/services/ai/providers/anthropic.ts
@@ -24,6 +24,9 @@ export const fetchAnthropicModels = async (apiKey: string): Promise<ModelOption[
     .map((model: Record<string, unknown>) => ({
       id: model.id as string,
       name: (model.display_name as string) || (model.id as string),
+      ...(typeof model.max_tokens === 'number' && {
+        maxOutputTokens: model.max_tokens as number,
+      }),
     }))
     .sort((modelA: ModelOption, modelB: ModelOption) => modelA.name.localeCompare(modelB.name));
 };
@@ -33,7 +36,7 @@ export const callAnthropic = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens = 100
+  maxTokens?: number
 ): Promise<string> => {
   const response = await fetchWithTimeout('https://api.anthropic.com/v1/messages', {
     method: 'POST',
@@ -45,7 +48,7 @@ export const callAnthropic = async (
     },
     body: JSON.stringify({
       model,
-      max_tokens: maxTokens,
+      max_tokens: maxTokens ?? 4096,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }],
     }),

--- a/src/services/ai/providers/gemini.ts
+++ b/src/services/ai/providers/gemini.ts
@@ -28,6 +28,9 @@ export const fetchGeminiModels = async (apiKey: string): Promise<ModelOption[]> 
     .map((model: Record<string, unknown>) => ({
       id: (model.name as string).replace('models/', ''),
       name: model.displayName as string,
+      ...(typeof model.outputTokenLimit === 'number' && {
+        maxOutputTokens: model.outputTokenLimit as number,
+      }),
     }));
 };
 

--- a/src/services/ai/providers/openRouter.ts
+++ b/src/services/ai/providers/openRouter.ts
@@ -26,10 +26,17 @@ export const fetchOpenRouterModels = async (apiKey: string): Promise<ModelOption
       const modelId = model.id as string;
       return OPENROUTER_TEXT_PREFIXES.some((prefix) => modelId.startsWith(prefix));
     })
-    .map((model: Record<string, unknown>) => ({
-      id: model.id as string,
-      name: (model.name as string) || (model.id as string),
-    }))
+    .map((model: Record<string, unknown>) => {
+      const topProvider = model.top_provider as Record<string, unknown> | undefined;
+      const maxCompletionTokens = topProvider?.max_completion_tokens;
+      return {
+        id: model.id as string,
+        name: (model.name as string) || (model.id as string),
+        ...(typeof maxCompletionTokens === 'number' && {
+          maxOutputTokens: maxCompletionTokens,
+        }),
+      };
+    })
     .sort((modelA: ModelOption, modelB: ModelOption) => modelA.name.localeCompare(modelB.name));
 };
 
@@ -38,7 +45,7 @@ export const callOpenRouter = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens = 100
+  maxTokens?: number
 ): Promise<string> => {
   const response = await fetchWithTimeout('https://openrouter.ai/api/v1/chat/completions', {
     method: 'POST',
@@ -52,7 +59,7 @@ export const callOpenRouter = async (
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
-      max_tokens: maxTokens,
+      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
     }),
   });
 

--- a/src/services/ai/providers/openai.ts
+++ b/src/services/ai/providers/openai.ts
@@ -35,7 +35,7 @@ export const callOpenAI = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens = 100
+  maxTokens?: number
 ): Promise<string> => {
   const response = await fetchWithTimeout('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -49,7 +49,7 @@ export const callOpenAI = async (
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
-      max_tokens: maxTokens,
+      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
     }),
   });
 

--- a/src/services/selectedState.ts
+++ b/src/services/selectedState.ts
@@ -20,16 +20,19 @@ import {
 
 let currentServiceId = '';
 let currentModelId = '';
+let currentMaxOutputTokens: number | undefined;
 
 export const getSelectedServiceId = (): string => currentServiceId;
 export const getSelectedModelId = (): string => currentModelId;
+export const getSelectedMaxOutputTokens = (): number | undefined => currentMaxOutputTokens;
 
 export const setSelectedServiceId = (id: string): void => {
   currentServiceId = id;
 };
 
-export const setSelectedModelId = (id: string): void => {
+export const setSelectedModelId = (id: string, maxOutputTokens?: number): void => {
   currentModelId = id;
+  currentMaxOutputTokens = maxOutputTokens;
 };
 
 export const initSelectedState = async (): Promise<void> => {

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -19,6 +19,7 @@ export interface StartOrganizePayload {
   folderTree: string;
   pathToIdMap: FolderPathMap;
   defaultParentId: string;
+  maxOutputTokens?: number;
 }
 
 export interface OrganizeCompletePayload {

--- a/src/types/services.ts
+++ b/src/types/services.ts
@@ -1,6 +1,7 @@
 export interface ModelOption {
   id: string;
   name: string;
+  maxOutputTokens?: number;
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary
- **Bug:** Hardcoded `ORGANIZE_MAX_TOKENS = 65536` exceeded Anthropic's 64,000 limit, causing `max_tokens: 65536 > 64000` errors for all Claude models
- **Fix:** Each provider now reads `maxOutputTokens` dynamically from its own models API — no hardcoded token limits
- **Flow:** Model selection → `selectedState` → `START_ORGANIZE` message → background script → API call, with a Chrome storage cache lookup as fallback

## Changes
| Provider | Source field | Behavior when undefined |
|---|---|---|
| Anthropic | `max_tokens` | Falls back to 4096 (required field) |
| Gemini | `outputTokenLimit` | Omits param (API uses default) |
| OpenRouter | `top_provider.max_completion_tokens` | Omits param (API uses default) |
| OpenAI | *(not exposed)* | Omits param (API uses default) |

## Files changed (12)
- `src/types/services.ts` — Added `maxOutputTokens?` to `ModelOption`
- `src/types/messaging.ts` — Added `maxOutputTokens?` to `StartOrganizePayload`
- `src/services/selectedState.ts` — Tracks `maxOutputTokens` in-memory
- `src/services/ai/providers/*` — Extract token limits from each provider's models API
- `src/services/ai/bulkOrganize.ts` — Replaced hardcoded constant with dynamic value + cache fallback
- `src/components/ServiceSelector/ServiceSelector.tsx` — Passes `maxOutputTokens` on model select (via ref to avoid re-render loop)
- `src/hooks/useBulkOrganize/useBulkOrganize.ts` — Sends `maxOutputTokens` in organize message
- `src/background.ts` — Forwards `maxOutputTokens` to `organizeBookmarks`

## Test plan
- [x] Tested with Anthropic API key — Claude models report correct `maxOutputTokens` (e.g. Opus 4: 32000, Haiku 3: 4096)
- [x] Tested with OpenRouter — models report `max_completion_tokens` correctly
- [x] Tested with Gemini — organize flow works end-to-end
- [x] Verified no re-render loop after `useRef` fix in ServiceSelector
- [x] Verified onboarding "Already have an API key?" paste flow works
- [x] Clean build with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)