### PR TITLE
feat: add Custom provider with user-defined API base URL

### DIFF
--- a/src/components/ApiKeyPanel/ApiKeyPanel.css
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.css
@@ -167,6 +167,29 @@
   font-weight: var(--font-weight-normal);
 }
 
+/* Base URL Section */
+.base-url-section {
+  margin-bottom: var(--spacing-md);
+}
+
+.base-url-label {
+  display: block;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin-bottom: var(--spacing-xs);
+}
+
+.base-url-input {
+  margin-bottom: var(--spacing-xs);
+}
+
+.base-url-hint {
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-light);
+  margin: 0;
+}
+
 /* API Key Card */
 .api-key-card {
   position: relative;

--- a/src/components/ApiKeyPanel/ApiKeyPanel.tsx
+++ b/src/components/ApiKeyPanel/ApiKeyPanel.tsx
@@ -38,6 +38,7 @@ const ApiKeyPanel = ({
   const {
     currentService,
     apiKeyInput,
+    baseUrlInput,
     selectedModel,
     modelsRefreshTrigger,
     hasExistingKey,
@@ -47,6 +48,7 @@ const ApiKeyPanel = ({
     handleServiceChange,
     handleModelChange,
     handleApiKeyInputChange,
+    handleBaseUrlInputChange,
     handleApiKeySave,
     handleApiKeyInputKeyDown,
     handleApiKeyRemove,
@@ -186,6 +188,21 @@ const ApiKeyPanel = ({
                 )}
               </button>
             )}
+            {currentService.baseUrlStorageKey && (
+              <div className="base-url-section">
+                <label className="base-url-label">Base URL</label>
+                <input
+                  type="url"
+                  value={baseUrlInput}
+                  onChange={handleBaseUrlInputChange}
+                  placeholder={currentService.baseUrlPlaceholder || 'https://api.example.com/v1'}
+                  autoComplete="off"
+                  className="base-url-input"
+                />
+                <p className="base-url-hint">OpenAI-compatible endpoint (e.g. Ollama, vLLM, LiteLLM)</p>
+              </div>
+            )}
+
             {showConfiguredState ? (
               <div className="api-key-configured">
                 <div className="api-key-configured-badge">
@@ -282,16 +299,18 @@ const ApiKeyPanel = ({
                   </div>
                 )}
 
-                <p className="api-key-help">
-                  Get your API key at{' '}
-                  <a
-                    href={currentService.helpLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {currentService.helpLinkText}
-                  </a>
-                </p>
+                {currentService.helpLink && (
+                  <p className="api-key-help">
+                    Get your API key at{' '}
+                    <a
+                      href={currentService.helpLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {currentService.helpLinkText}
+                    </a>
+                  </p>
+                )}
               </>
             )}
           </div>

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -44,6 +44,18 @@ export const SERVICES: Record<string, ServiceConfig> = {
     helpLinkText: 'OpenRouter Dashboard',
     validateKey: (key: string) => key.startsWith('sk-or-') && key.length >= 30,
   },
+  custom: {
+    id: 'custom',
+    name: 'Custom',
+    label: 'API Key',
+    storageKey: 'customApiKey',
+    placeholder: 'Enter your API key',
+    helpLink: '',
+    helpLinkText: '',
+    baseUrlStorageKey: 'customBaseUrl',
+    baseUrlPlaceholder: 'https://api.example.com/v1',
+    validateKey: (key: string) => key.length >= 1,
+  },
 };
 
 export const DEFAULT_SERVICE_ID = 'google';

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -47,14 +47,14 @@ export const SERVICES: Record<string, ServiceConfig> = {
   custom: {
     id: 'custom',
     name: 'Custom',
-    label: 'API Key',
+    label: 'API Key (optional)',
     storageKey: 'customApiKey',
-    placeholder: 'Enter your API key',
+    placeholder: 'Leave empty for local endpoints (e.g. Ollama)',
     helpLink: '',
     helpLinkText: '',
     baseUrlStorageKey: 'customBaseUrl',
     baseUrlPlaceholder: 'https://api.example.com/v1',
-    validateKey: (key: string) => key.length >= 1,
+    validateKey: () => true,
   },
 };
 

--- a/src/hooks/apiKeyPanel/handlers/handleApiKeyRemove.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleApiKeyRemove.ts
@@ -1,4 +1,5 @@
 import { type ApiKeyPanelHandlerDeps } from '../types';
+import { removeCustomOriginPermission } from '../../../utils/customProviderPermissions';
 
 type HandleApiKeyRemoveDeps = Pick<
   ApiKeyPanelHandlerDeps,
@@ -16,11 +17,23 @@ export const createHandleApiKeyRemove = (deps: HandleApiKeyRemoveDeps) => {
     if (!confirmRemoval) return;
 
     try {
+      let storedBaseUrl = '';
+
+      if (currentService.baseUrlStorageKey) {
+        const result = await chrome.storage.local.get([currentService.baseUrlStorageKey]);
+        storedBaseUrl = result[currentService.baseUrlStorageKey] || '';
+      }
+
       const keysToRemove = [currentService.storageKey];
       if (currentService.baseUrlStorageKey) {
         keysToRemove.push(currentService.baseUrlStorageKey);
       }
       await chrome.storage.local.remove(keysToRemove);
+
+      if (storedBaseUrl) {
+        await removeCustomOriginPermission(storedBaseUrl);
+      }
+
       setHasExistingKey(false);
       setApiKeyInput('');
       onClose?.();

--- a/src/hooks/apiKeyPanel/handlers/handleApiKeyRemove.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleApiKeyRemove.ts
@@ -16,7 +16,11 @@ export const createHandleApiKeyRemove = (deps: HandleApiKeyRemoveDeps) => {
     if (!confirmRemoval) return;
 
     try {
-      await chrome.storage.local.remove([currentService.storageKey]);
+      const keysToRemove = [currentService.storageKey];
+      if (currentService.baseUrlStorageKey) {
+        keysToRemove.push(currentService.baseUrlStorageKey);
+      }
+      await chrome.storage.local.remove(keysToRemove);
       setHasExistingKey(false);
       setApiKeyInput('');
       onClose?.();

--- a/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
@@ -10,6 +10,7 @@ interface HandleApiKeySaveDeps extends Pick<
   | 'setApiKeyInput'
   | 'showStatusMessage'
 > {
+  baseUrlInput: string;
   setStatus: (status: ApiKeyPanelStatusMessage) => void;
   setIsEditingKey: (value: boolean) => void;
   showButtonError: (message: string) => void;
@@ -21,6 +22,7 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
     const {
       currentService,
       apiKeyInput,
+      baseUrlInput,
       setHasExistingKey,
       setApiKeyInput,
       showStatusMessage,
@@ -31,6 +33,22 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
     } = deps;
 
     const trimmedKey = apiKeyInput.trim();
+
+    if (currentService.baseUrlStorageKey) {
+      const trimmedUrl = baseUrlInput.trim();
+      if (!trimmedUrl) {
+        showButtonError('Please enter a base URL');
+        return;
+      }
+      try {
+        new URL(trimmedUrl);
+      } catch {
+        showButtonError('Invalid base URL format');
+        return;
+      }
+      const normalizedUrl = trimmedUrl.replace(/\/+$/, '');
+      await chrome.storage.local.set({ [currentService.baseUrlStorageKey]: normalizedUrl });
+    }
 
     if (!trimmedKey) {
       showButtonError('Please enter an API key');

--- a/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
@@ -1,6 +1,12 @@
 import { type ApiKeyPanelHandlerDeps, type ApiKeyPanelStatusMessage } from '../types';
 import { fetchModelsForProvider } from '../../../services/ai/providerUtils';
 import { MODELS_CACHE_KEY_PREFIX } from '../../../config/services';
+import {
+  getCustomOriginPermission,
+  normalizeCustomBaseUrl,
+  removeCustomOriginPermission,
+  requestCustomOriginPermission,
+} from '../../../utils/customProviderPermissions';
 
 interface HandleApiKeySaveDeps extends Pick<
   ApiKeyPanelHandlerDeps,
@@ -33,22 +39,10 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
     } = deps;
 
     const trimmedKey = apiKeyInput.trim();
-
-    if (currentService.baseUrlStorageKey) {
-      const trimmedUrl = baseUrlInput.trim();
-      if (!trimmedUrl) {
-        showButtonError('Please enter a base URL');
-        return;
-      }
-      try {
-        new URL(trimmedUrl);
-      } catch {
-        showButtonError('Invalid base URL format');
-        return;
-      }
-      const normalizedUrl = trimmedUrl.replace(/\/+$/, '');
-      await chrome.storage.local.set({ [currentService.baseUrlStorageKey]: normalizedUrl });
-    }
+    let normalizedBaseUrl = '';
+    let previousBaseUrl = '';
+    let requestedOriginPermission = '';
+    let shouldRollbackRequestedPermission = false;
 
     if (!trimmedKey) {
       showButtonError('Please enter an API key');
@@ -61,16 +55,56 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
     }
 
     try {
-      await chrome.storage.local.set({ [currentService.storageKey]: trimmedKey });
-      setHasExistingKey(true);
-      setApiKeyInput('');
+      if (currentService.baseUrlStorageKey) {
+        try {
+          normalizedBaseUrl = normalizeCustomBaseUrl(baseUrlInput);
+        } catch (error) {
+          showButtonError(error instanceof Error ? error.message : 'Invalid base URL format');
+          return;
+        }
+
+        requestedOriginPermission = getCustomOriginPermission(normalizedBaseUrl);
+        const permissionGranted = await requestCustomOriginPermission(normalizedBaseUrl);
+
+        if (!permissionGranted) {
+          setStatus({
+            message: 'Host access was not granted. Allow access to this endpoint to use the Custom provider.',
+            type: 'error',
+            showGoToApp: false,
+          });
+          return;
+        }
+
+        const storedBaseUrlResult = await chrome.storage.local.get([currentService.baseUrlStorageKey]);
+        previousBaseUrl = storedBaseUrlResult[currentService.baseUrlStorageKey] as string || '';
+        const previousOriginPermission = previousBaseUrl
+          ? getCustomOriginPermission(previousBaseUrl)
+          : '';
+
+        shouldRollbackRequestedPermission = requestedOriginPermission !== previousOriginPermission;
+      }
 
       showStatusMessage('Validating key & loading models...', 'loading');
 
-      // Fetching models validates the key implicitly — if the key is invalid, this throws
-      const models = await fetchModelsForProvider(currentService.id, trimmedKey);
+      // Fetching models validates the key implicitly — if the key is invalid, this throws.
+      const models = await fetchModelsForProvider(currentService.id, trimmedKey, normalizedBaseUrl || undefined);
+
+      await chrome.storage.local.set({
+        [currentService.storageKey]: trimmedKey,
+        ...(currentService.baseUrlStorageKey && { [currentService.baseUrlStorageKey]: normalizedBaseUrl }),
+      });
+      setHasExistingKey(true);
+      setApiKeyInput('');
+      const shouldRemovePreviousPermission = (
+        previousBaseUrl &&
+        getCustomOriginPermission(previousBaseUrl) !== requestedOriginPermission
+      );
 
       if (models.length === 0) {
+        if (shouldRemovePreviousPermission) {
+          await removeCustomOriginPermission(previousBaseUrl);
+        }
+
         setStatus({
           message: 'Key accepted but no models found.',
           type: 'default',
@@ -92,9 +126,21 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
       });
       setIsEditingKey(false);
 
+      if (shouldRemovePreviousPermission) {
+        await removeCustomOriginPermission(previousBaseUrl);
+      }
+
       // Signal ServiceSelector to reload models from cache
       onModelsLoaded();
     } catch (error) {
+      if (currentService.baseUrlStorageKey && shouldRollbackRequestedPermission) {
+        try {
+          await removeCustomOriginPermission(normalizedBaseUrl);
+        } catch (permissionError) {
+          console.warn('Failed to roll back custom host permission:', permissionError);
+        }
+      }
+
       console.error('Failed to save or validate API key:', error);
       const errorMessage = error instanceof Error ? error.message : 'Connection failed';
       setStatus({

--- a/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleApiKeySave.ts
@@ -44,13 +44,8 @@ export const createHandleApiKeySave = (deps: HandleApiKeySaveDeps) => {
     let requestedOriginPermission = '';
     let shouldRollbackRequestedPermission = false;
 
-    if (!trimmedKey) {
-      showButtonError('Please enter an API key');
-      return;
-    }
-
     if (!currentService.validateKey(trimmedKey)) {
-      showButtonError('Invalid API key format');
+      showButtonError(trimmedKey ? 'Invalid API key format' : 'Please enter an API key');
       return;
     }
 

--- a/src/hooks/apiKeyPanel/handlers/handleServiceChange.ts
+++ b/src/hooks/apiKeyPanel/handlers/handleServiceChange.ts
@@ -1,10 +1,10 @@
 import { getService } from '../../../config/services';
 import { type ApiKeyPanelHandlerDeps } from '../types';
 
-interface HandleServiceChangeDeps extends Pick<
+type HandleServiceChangeDeps = Pick<
   ApiKeyPanelHandlerDeps,
   'setCurrentService' | 'setApiKeyInput' | 'clearStatus' | 'checkExistingApiKey' | 'setSelectedModel'
-> {}
+>;
 
 export const createHandleServiceChange = (deps: HandleServiceChangeDeps) => {
   return (serviceId: string): void => {

--- a/src/hooks/apiKeyPanel/useApiKeyPanel.ts
+++ b/src/hooks/apiKeyPanel/useApiKeyPanel.ts
@@ -16,6 +16,7 @@ import {
 export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProps) => {
   const [currentService, setCurrentService] = useState<ServiceConfig>(EMPTY_SERVICE);
   const [apiKeyInput, setApiKeyInput] = useState('');
+  const [baseUrlInput, setBaseUrlInput] = useState('');
   const [selectedModel, setSelectedModel] = useState<string>('');
   const [hasExistingKey, setHasExistingKey] = useState(false);
   const [isEditingKey, setIsEditingKey] = useState(false);
@@ -108,6 +109,7 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
     () => createHandleApiKeySave({
       currentService,
       apiKeyInput,
+      baseUrlInput,
       setHasExistingKey,
       setApiKeyInput,
       showStatusMessage,
@@ -116,7 +118,7 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
       setIsEditingKey,
       onModelsLoaded: handleModelsLoaded,
     }),
-    [currentService, apiKeyInput, showStatusMessage, showButtonError, handleModelsLoaded]
+    [currentService, apiKeyInput, baseUrlInput, showStatusMessage, showButtonError, handleModelsLoaded]
   );
 
   const handleApiKeyRemove = useMemo(
@@ -133,6 +135,13 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
   const handleApiKeyInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {
       setApiKeyInput(event.target.value);
+    },
+    []
+  );
+
+  const handleBaseUrlInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>): void => {
+      setBaseUrlInput(event.target.value);
     },
     []
   );
@@ -176,12 +185,23 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
   }, [isOpen, currentService, checkExistingApiKey]);
 
   useEffect(() => {
+    if (currentService.baseUrlStorageKey) {
+      chrome.storage.local.get([currentService.baseUrlStorageKey]).then(result => {
+        setBaseUrlInput(result[currentService.baseUrlStorageKey!] || '');
+      });
+    } else {
+      setBaseUrlInput('');
+    }
+  }, [currentService]);
+
+  useEffect(() => {
     setCanClosePanel(canClose);
   }, [canClose]);
 
   return {
     currentService,
     apiKeyInput,
+    baseUrlInput,
     selectedModel,
     modelsRefreshTrigger,
     hasExistingKey,
@@ -192,6 +212,7 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
     handleServiceChange,
     handleModelChange,
     handleApiKeyInputChange,
+    handleBaseUrlInputChange,
     handleApiKeySave,
     handleApiKeyInputKeyDown,
     handleApiKeyRemove,

--- a/src/hooks/apiKeyPanel/useApiKeyPanel.ts
+++ b/src/hooks/apiKeyPanel/useApiKeyPanel.ts
@@ -32,8 +32,12 @@ export const useApiKeyPanel = ({ isOpen, canClose, onClose }: UseApiKeyPanelProp
   const [modelsRefreshTrigger, setModelsRefreshTrigger] = useState(0);
 
   const checkExistingApiKey = useCallback(async (service: ServiceConfig): Promise<boolean> => {
-    const result = await chrome.storage.local.get([service.storageKey]);
-    const keyExists = !!result[service.storageKey];
+    const keys = [service.storageKey, ...(service.baseUrlStorageKey ? [service.baseUrlStorageKey] : [])];
+    const result = await chrome.storage.local.get(keys);
+    // For providers with optional API key (validateKey('') === true), a saved base URL counts as configured.
+    const keyExists = service.validateKey('') && service.baseUrlStorageKey
+      ? !!result[service.baseUrlStorageKey]
+      : !!result[service.storageKey];
     setHasExistingKey(keyExists);
     return keyExists;
   }, []);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,6 +31,8 @@
     "https://generativelanguage.googleapis.com/*",
     "https://api.openai.com/*",
     "https://api.anthropic.com/*",
-    "https://openrouter.ai/*"
+    "https://openrouter.ai/*",
+    "http://*/*",
+    "https://*/*"
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,13 +25,16 @@
     "activeTab",
     "storage",
     "scripting",
-    "alarms"
+    "alarms",
+    "permissions"
   ],
   "host_permissions": [
     "https://generativelanguage.googleapis.com/*",
     "https://api.openai.com/*",
     "https://api.anthropic.com/*",
-    "https://openrouter.ai/*",
+    "https://openrouter.ai/*"
+  ],
+  "optional_host_permissions": [
     "http://*/*",
     "https://*/*"
   ]

--- a/src/services/ai/providerUtils.ts
+++ b/src/services/ai/providerUtils.ts
@@ -1,9 +1,16 @@
 import { SERVICES } from '../../config/services';
 import { type ModelOption } from '../../types/services';
 import {
-  callGemini, callOpenAI, callAnthropic, callOpenRouter,
-  fetchGeminiModels, fetchOpenAIModels, fetchAnthropicModels, fetchOpenRouterModels,
+  callGemini, callOpenAI, callAnthropic, callOpenRouter, callCustom,
+  fetchGeminiModels, fetchOpenAIModels, fetchAnthropicModels, fetchOpenRouterModels, fetchCustomModels,
 } from './providers';
+
+const getCustomBaseUrl = async (): Promise<string> => {
+  const result = await chrome.storage.local.get(['customBaseUrl']);
+  const baseUrl = result.customBaseUrl;
+  if (!baseUrl) throw new Error('No base URL configured. Please set a base URL in Settings.');
+  return baseUrl;
+};
 
 export const fetchModelsForProvider = async (
   serviceId: string,
@@ -18,6 +25,8 @@ export const fetchModelsForProvider = async (
       return fetchAnthropicModels(apiKey);
     case 'openrouter':
       return fetchOpenRouterModels(apiKey);
+    case 'custom':
+      return fetchCustomModels(apiKey, await getCustomBaseUrl());
     default:
       throw new Error(`Unsupported service: ${serviceId}`);
   }
@@ -56,6 +65,8 @@ export const callProvider = async (
       return callAnthropic(apiKey, systemPrompt, userPrompt, model, maxTokens);
     case 'openrouter':
       return callOpenRouter(apiKey, systemPrompt, userPrompt, model, maxTokens);
+    case 'custom':
+      return callCustom(apiKey, await getCustomBaseUrl(), systemPrompt, userPrompt, model, maxTokens);
     default:
       throw new Error(`Unsupported service: ${serviceId}`);
   }

--- a/src/services/ai/providerUtils.ts
+++ b/src/services/ai/providerUtils.ts
@@ -14,7 +14,8 @@ const getCustomBaseUrl = async (): Promise<string> => {
 
 export const fetchModelsForProvider = async (
   serviceId: string,
-  apiKey: string
+  apiKey: string,
+  customBaseUrl?: string
 ): Promise<ModelOption[]> => {
   switch (serviceId) {
     case 'google':
@@ -26,7 +27,7 @@ export const fetchModelsForProvider = async (
     case 'openrouter':
       return fetchOpenRouterModels(apiKey);
     case 'custom':
-      return fetchCustomModels(apiKey, await getCustomBaseUrl());
+      return fetchCustomModels(apiKey, customBaseUrl || await getCustomBaseUrl());
     default:
       throw new Error(`Unsupported service: ${serviceId}`);
   }

--- a/src/services/ai/providerUtils.ts
+++ b/src/services/ai/providerUtils.ts
@@ -6,8 +6,10 @@ import {
 } from './providers';
 
 const getCustomBaseUrl = async (): Promise<string> => {
-  const result = await chrome.storage.local.get(['customBaseUrl']);
-  const baseUrl = result.customBaseUrl;
+  const storageKey = SERVICES.custom.baseUrlStorageKey;
+  if (!storageKey) throw new Error('Custom provider is missing a base URL storage key');
+  const result = await chrome.storage.local.get([storageKey]);
+  const baseUrl = result[storageKey];
   if (!baseUrl) throw new Error('No base URL configured. Please set a base URL in Settings.');
   return baseUrl;
 };
@@ -40,9 +42,10 @@ export const getApiKey = async (serviceId: string): Promise<string> => {
   }
 
   const storageResult = await chrome.storage.local.get([service.storageKey]);
-  const apiKey = storageResult[service.storageKey];
+  const apiKey = storageResult[service.storageKey] || '';
 
-  if (!apiKey) {
+  // Some providers (e.g. Custom for local LLM runners) accept an empty key.
+  if (!apiKey && !service.validateKey('')) {
     throw new Error(`No API key found for ${service.name}`);
   }
 

--- a/src/services/ai/providers/custom.ts
+++ b/src/services/ai/providers/custom.ts
@@ -1,0 +1,68 @@
+import { fetchWithTimeout, throwApiResponseError } from '../../../utils/helpers';
+import { type ModelOption } from '../../../types/services';
+
+export const fetchCustomModels = async (apiKey: string, baseUrl: string): Promise<ModelOption[]> => {
+  const response = await fetchWithTimeout(`${baseUrl}/models`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (!response.ok) {
+    await throwApiResponseError('Custom', response);
+  }
+
+  const data = await response.json();
+
+  if (!Array.isArray(data?.data)) {
+    throw new Error('Unexpected response from models endpoint. Expected OpenAI-compatible format.');
+  }
+
+  return data.data
+    .map((model: Record<string, unknown>) => ({
+      id: model.id as string,
+      name: (model.name as string) || (model.id as string),
+    }))
+    .sort((modelA: ModelOption, modelB: ModelOption) => modelA.name.localeCompare(modelB.name));
+};
+
+export const callCustom = async (
+  apiKey: string,
+  baseUrl: string,
+  systemPrompt: string,
+  userPrompt: string,
+  model: string,
+  maxTokens?: number
+): Promise<string> => {
+  const response = await fetchWithTimeout(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+    }),
+  });
+
+  if (!response.ok) {
+    await throwApiResponseError('Custom', response);
+  }
+
+  const data = await response.json();
+
+  if (data?.choices?.[0]?.finish_reason === 'length') {
+    throw new Error('Response was truncated — the model ran out of output tokens. Please try again.');
+  }
+
+  const text = data?.choices?.[0]?.message?.content;
+
+  if (!text) {
+    throw new Error('No response from custom endpoint');
+  }
+
+  return text.trim();
+};

--- a/src/services/ai/providers/custom.ts
+++ b/src/services/ai/providers/custom.ts
@@ -1,9 +1,14 @@
-import { fetchWithTimeout, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
+
+const buildAuthHeaders = (apiKey: string): Record<string, string> => {
+  const trimmed = apiKey.trim();
+  return trimmed ? { Authorization: `Bearer ${trimmed}` } : {};
+};
 
 export const fetchCustomModels = async (apiKey: string, baseUrl: string): Promise<ModelOption[]> => {
   const response = await fetchWithTimeout(`${baseUrl}/models`, {
-    headers: { Authorization: `Bearer ${apiKey}` },
+    headers: buildAuthHeaders(apiKey),
   });
 
   if (!response.ok) {
@@ -17,9 +22,12 @@ export const fetchCustomModels = async (apiKey: string, baseUrl: string): Promis
   }
 
   return data.data
-    .map((model: Record<string, unknown>) => ({
-      id: model.id as string,
-      name: (model.name as string) || (model.id as string),
+    .filter((model: Record<string, unknown>): model is { id: string; name?: unknown } =>
+      typeof model?.id === 'string' && model.id.length > 0
+    )
+    .map((model: { id: string; name?: unknown }) => ({
+      id: model.id,
+      name: typeof model.name === 'string' && model.name.length > 0 ? model.name : model.id,
     }))
     .sort((modelA: ModelOption, modelB: ModelOption) => modelA.name.localeCompare(modelB.name));
 };
@@ -30,23 +38,28 @@ export const callCustom = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens?: number
+  maxTokens?: number,
+  bookmarkCount?: number
 ): Promise<string> => {
-  const response = await fetchWithTimeout(`${baseUrl}/chat/completions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
+  const response = await fetchWithTimeout(
+    `${baseUrl}/chat/completions`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...buildAuthHeaders(apiKey),
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+      }),
     },
-    body: JSON.stringify({
-      model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ],
-      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
-    }),
-  });
+    getAiTimeoutMs(bookmarkCount)
+  );
 
   if (!response.ok) {
     await throwApiResponseError('Custom', response);

--- a/src/services/ai/providers/index.ts
+++ b/src/services/ai/providers/index.ts
@@ -2,3 +2,4 @@ export { callGemini, fetchGeminiModels } from './gemini';
 export { callOpenAI, fetchOpenAIModels } from './openai';
 export { callAnthropic, fetchAnthropicModels } from './anthropic';
 export { callOpenRouter, fetchOpenRouterModels } from './openRouter';
+export { callCustom, fetchCustomModels } from './custom';

--- a/src/types/services.ts
+++ b/src/types/services.ts
@@ -14,4 +14,6 @@ export interface ServiceConfig {
   helpLinkText: string;
   freeTierNote?: string;
   validateKey: (key: string) => boolean;
+  baseUrlStorageKey?: string;
+  baseUrlPlaceholder?: string;
 }

--- a/src/utils/customProviderPermissions.ts
+++ b/src/utils/customProviderPermissions.ts
@@ -1,0 +1,55 @@
+const SUPPORTED_CUSTOM_PROVIDER_PROTOCOLS = new Set(['http:', 'https:']);
+
+const parseCustomBaseUrl = (baseUrl: string): URL => {
+  let url: URL;
+
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error('Invalid base URL format');
+  }
+
+  if (!SUPPORTED_CUSTOM_PROVIDER_PROTOCOLS.has(url.protocol)) {
+    throw new Error('Base URL must start with http:// or https://');
+  }
+
+  if (url.username || url.password) {
+    throw new Error('Base URL cannot include embedded credentials');
+  }
+
+  if (url.search || url.hash) {
+    throw new Error('Base URL cannot include query parameters or fragments');
+  }
+
+  return url;
+};
+
+export const normalizeCustomBaseUrl = (baseUrlInput: string): string => {
+  const trimmedUrl = baseUrlInput.trim();
+
+  if (!trimmedUrl) {
+    throw new Error('Please enter a base URL');
+  }
+
+  const url = parseCustomBaseUrl(trimmedUrl);
+  const normalizedPath = url.pathname.replace(/\/+$/, '');
+
+  return normalizedPath ? `${url.origin}${normalizedPath}` : url.origin;
+};
+
+export const getCustomOriginPermission = (baseUrl: string): string => {
+  const url = parseCustomBaseUrl(baseUrl);
+  return `${url.protocol}//${url.hostname}/*`;
+};
+
+export const requestCustomOriginPermission = async (baseUrl: string): Promise<boolean> => {
+  return chrome.permissions.request({
+    origins: [getCustomOriginPermission(baseUrl)],
+  });
+};
+
+export const removeCustomOriginPermission = async (baseUrl: string): Promise<void> => {
+  await chrome.permissions.remove({
+    origins: [getCustomOriginPermission(baseUrl)],
+  });
+};

--- a/src/utils/customProviderPermissions.ts
+++ b/src/utils/customProviderPermissions.ts
@@ -1,5 +1,12 @@
 const SUPPORTED_CUSTOM_PROVIDER_PROTOCOLS = new Set(['http:', 'https:']);
 
+const isLoopbackHost = (hostname: string): boolean => {
+  if (hostname === 'localhost' || hostname === '[::1]') return true;
+  if (hostname.endsWith('.localhost')) return true;
+  if (hostname.startsWith('127.')) return true;
+  return false;
+};
+
 const parseCustomBaseUrl = (baseUrl: string): URL => {
   let url: URL;
 
@@ -11,6 +18,10 @@ const parseCustomBaseUrl = (baseUrl: string): URL => {
 
   if (!SUPPORTED_CUSTOM_PROVIDER_PROTOCOLS.has(url.protocol)) {
     throw new Error('Base URL must start with http:// or https://');
+  }
+
+  if (url.protocol === 'http:' && !isLoopbackHost(url.hostname)) {
+    throw new Error('http:// is only allowed for localhost. Use https:// for remote endpoints — otherwise the API key travels in cleartext.');
   }
 
   if (url.username || url.password) {


### PR DESCRIPTION
## Summary
- Add a **Custom** AI provider option that lets users connect any OpenAI-compatible endpoint (Ollama, vLLM, LiteLLM, LocalAI, etc.) by entering a base URL and API key
- Base URL input appears in Settings when "Custom" is selected, with validation and hint text
- Uses OpenAI-compatible `/models` and `/chat/completions` endpoints
- Broadens `host_permissions` in manifest to support arbitrary user-specified URLs

## Changes
- New `src/services/ai/providers/custom.ts` — OpenAI-compatible provider with `fetchCustomModels` and `callCustom`
- Updated `ServiceConfig` type with optional `baseUrlStorageKey` and `baseUrlPlaceholder`
- Added `custom` entry in `config/services.ts`
- Wired custom provider into `providerUtils.ts` dispatch (both `fetchModelsForProvider` and `callProvider`)
- Added base URL state management in `useApiKeyPanel` hook and save/remove handlers
- Updated `ApiKeyPanel` UI to show base URL input when custom provider is selected
- Added `http://*/*` and `https://*/*` to manifest `host_permissions`

## Test plan
- [ ] Select "Custom" provider → base URL input appears
- [ ] Enter base URL + API key → Save → models fetched from custom endpoint
- [ ] Single-page organize works with custom provider
- [ ] Bulk organize works with custom provider
- [ ] Switch back to built-in provider (e.g. Gemini) → everything still works
- [ ] Remove custom API key → base URL also cleared from storage
- [ ] Invalid base URL → shows error before saving

🤖 Generated with [Claude Code](https://claude.ai/claude-code)