### PR TITLE
fix: scale AI request timeout with bookmark count

### DIFF
--- a/src/services/ai/bulkOrganize.ts
+++ b/src/services/ai/bulkOrganize.ts
@@ -106,7 +106,8 @@ export const organizeBookmarks = async (
     BULK_ORGANIZE_SYSTEM_PROMPT,
     userPrompt,
     modelId,
-    resolvedTokens
+    resolvedTokens,
+    bookmarks.length
   );
 
   return parseBulkOrganizeResponse(responseText, bookmarks, pathToIdMap);

--- a/src/services/ai/providerUtils.ts
+++ b/src/services/ai/providerUtils.ts
@@ -45,17 +45,18 @@ export const callProvider = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens?: number
+  maxTokens?: number,
+  bookmarkCount?: number
 ): Promise<string> => {
   switch (serviceId) {
     case 'google':
-      return callGemini(apiKey, systemPrompt, userPrompt, model, maxTokens);
+      return callGemini(apiKey, systemPrompt, userPrompt, model, maxTokens, bookmarkCount);
     case 'openai':
-      return callOpenAI(apiKey, systemPrompt, userPrompt, model, maxTokens);
+      return callOpenAI(apiKey, systemPrompt, userPrompt, model, maxTokens, bookmarkCount);
     case 'anthropic':
-      return callAnthropic(apiKey, systemPrompt, userPrompt, model, maxTokens);
+      return callAnthropic(apiKey, systemPrompt, userPrompt, model, maxTokens, bookmarkCount);
     case 'openrouter':
-      return callOpenRouter(apiKey, systemPrompt, userPrompt, model, maxTokens);
+      return callOpenRouter(apiKey, systemPrompt, userPrompt, model, maxTokens, bookmarkCount);
     default:
       throw new Error(`Unsupported service: ${serviceId}`);
   }

--- a/src/services/ai/providers/anthropic.ts
+++ b/src/services/ai/providers/anthropic.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 export const fetchAnthropicModels = async (apiKey: string): Promise<ModelOption[]> => {
@@ -36,23 +36,28 @@ export const callAnthropic = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens?: number
+  maxTokens?: number,
+  bookmarkCount?: number
 ): Promise<string> => {
-  const response = await fetchWithTimeout('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-      'anthropic-dangerous-direct-browser-access': 'true',
+  const response = await fetchWithTimeout(
+    'https://api.anthropic.com/v1/messages',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens ?? 4096,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userPrompt }],
+      }),
     },
-    body: JSON.stringify({
-      model,
-      max_tokens: maxTokens ?? 4096,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: userPrompt }],
-    }),
-  });
+    getAiTimeoutMs(bookmarkCount)
+  );
 
   if (!response.ok) {
     await throwApiResponseError('Anthropic', response);

--- a/src/services/ai/providers/gemini.ts
+++ b/src/services/ai/providers/gemini.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const GEMINI_MODEL_PREFIX = 'models/gemini-';
@@ -39,24 +39,29 @@ export const callGemini = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens?: number
+  maxTokens?: number,
+  bookmarkCount?: number
 ): Promise<string> => {
   const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 
-  const response = await fetchWithTimeout(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-goog-api-key': apiKey,
-    },
-    body: JSON.stringify({
-      systemInstruction: { parts: [{ text: systemPrompt }] },
-      contents: [{ parts: [{ text: userPrompt }] }],
-      ...(maxTokens !== undefined && {
-        generationConfig: { maxOutputTokens: maxTokens },
+  const response = await fetchWithTimeout(
+    endpoint,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: systemPrompt }] },
+        contents: [{ parts: [{ text: userPrompt }] }],
+        ...(maxTokens !== undefined && {
+          generationConfig: { maxOutputTokens: maxTokens },
+        }),
       }),
-    }),
-  });
+    },
+    getAiTimeoutMs(bookmarkCount)
+  );
 
   if (!response.ok) {
     await throwApiResponseError('Gemini', response);

--- a/src/services/ai/providers/openRouter.ts
+++ b/src/services/ai/providers/openRouter.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const OPENROUTER_TEXT_PREFIXES = [
@@ -45,23 +45,28 @@ export const callOpenRouter = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens?: number
+  maxTokens?: number,
+  bookmarkCount?: number
 ): Promise<string> => {
-  const response = await fetchWithTimeout('https://openrouter.ai/api/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
+  const response = await fetchWithTimeout(
+    'https://openrouter.ai/api/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+      }),
     },
-    body: JSON.stringify({
-      model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ],
-      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
-    }),
-  });
+    getAiTimeoutMs(bookmarkCount)
+  );
 
   if (!response.ok) {
     await throwApiResponseError('OpenRouter', response);

--- a/src/services/ai/providers/openai.ts
+++ b/src/services/ai/providers/openai.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const OPENAI_CHAT_PREFIXES = ['gpt-', 'o1', 'o3', 'o4', 'chatgpt-'];
@@ -35,23 +35,28 @@ export const callOpenAI = async (
   systemPrompt: string,
   userPrompt: string,
   model: string,
-  maxTokens?: number
+  maxTokens?: number,
+  bookmarkCount?: number
 ): Promise<string> => {
-  const response = await fetchWithTimeout('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
+  const response = await fetchWithTimeout(
+    'https://api.openai.com/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+      }),
     },
-    body: JSON.stringify({
-      model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ],
-      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
-    }),
-  });
+    getAiTimeoutMs(bookmarkCount)
+  );
 
   if (!response.ok) {
     await throwApiResponseError('OpenAI', response);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,9 +1,18 @@
-const AI_REQUEST_TIMEOUT_MS = 45_000;
+const TIMEOUT_BASE_MS = 60_000;
+const TIMEOUT_PER_BOOKMARK_MS = 500;
+const TIMEOUT_CEILING_MS = 300_000;
+
+export const getAiTimeoutMs = (bookmarkCount: number = 1): number => {
+  return Math.min(
+    TIMEOUT_BASE_MS + bookmarkCount * TIMEOUT_PER_BOOKMARK_MS,
+    TIMEOUT_CEILING_MS
+  );
+};
 
 export const fetchWithTimeout = async (
   url: string,
   options: RequestInit = {},
-  timeoutMs = AI_REQUEST_TIMEOUT_MS
+  timeoutMs = getAiTimeoutMs()
 ): Promise<Response> => {
   if (options.signal) {
     throw new Error('fetchWithTimeout does not support passing an external AbortSignal.');


### PR DESCRIPTION
## Summary

Replaces the hardcoded 45s timeout in `fetchWithTimeout` with a function that scales the timeout to the size of the AI request. Fixes `Request timed out` errors during bulk organize on slower models.

**Before:** All AI requests share a single 45s budget — too tight for bulk organize with hundreds of bookmarks, especially on reasoning models.

**After:** Timeout is computed per call:

```ts
timeout = min(60s + 500ms × bookmarkCount, 5min)
```

| Bookmarks | New Timeout | Old Timeout |
|---|---|---|
| 1 (single organize) | 60.5s | 45s |
| 193 | 156.5s | 45s ❌ |
| 480+ | 5 min (capped) | 45s ❌ |

The 5-minute ceiling exists to avoid Chrome MV3 service worker lifecycle issues on very large batches.

## Why this design

- **Not hardcoded** — the value is a function of work size, not an arbitrary constant
- **Provider-agnostic** — change is in the shared `fetchWithTimeout` helper, so all 4 providers (Gemini, OpenAI, Anthropic, OpenRouter) and any future ones (e.g. PR #37's Custom provider) benefit automatically
- **Bounded** — the ceiling caps the worst case at 5 minutes, protecting against service worker termination and bad UX during true hangs
- **Backwards compatible** — `bookmarkCount` is optional everywhere; calls without it default to 1 (60s), which also bumps the previously-too-tight 45s for model-listing endpoints

## Changes

- `src/utils/helpers.ts` — new `getAiTimeoutMs(bookmarkCount)` helper, replaces `AI_REQUEST_TIMEOUT_MS` constant
- `src/services/ai/providerUtils.ts` — `callProvider` accepts optional `bookmarkCount`, threads to providers
- `src/services/ai/providers/{gemini,openai,anthropic,openRouter}.ts` — accept `bookmarkCount`, pass computed timeout to `fetchWithTimeout`
- `src/services/ai/bulkOrganize.ts` — passes `bookmarks.length` when calling provider
- `src/services/ai/index.ts` — unchanged; single organize uses default (1 bookmark = 60s)

## Test plan

Validated locally on `dist/` build with real API calls:

- [x] Single page organize on Gemini 2.5 Flash-Lite → ~3s
- [x] Bulk organize 193 bookmarks on Gemini 2.5 Flash → 57s
- [x] Bulk organize 193 bookmarks on OpenRouter Qwen reasoning → 1m13s
- [x] Bulk organize 196 bookmarks on OpenRouter DeepSeek R1 (free) → ~2m37s (worst case, completed without timeout)
- [x] Cancel mid-flight still returns to bookmark picker
- [x] `tsc && vite build` — clean

## Related

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)