### PR TITLE
fix: accept new API key formats (issue #41)

### DIFF
--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -12,7 +12,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
     helpLink: 'https://aistudio.google.com/apikey',
     helpLinkText: 'Google AI Studio',
     freeTierNote: 'Free tier has rate limits. Some models (e.g. Pro) may require a paid plan or have very low daily quotas.',
-    validateKey: (key: string) => key.startsWith('AI') && key.length >= 30,
+    validateKey: (key: string) => key.trim().length >= 20,
   },
   openai: {
     id: 'openai',
@@ -22,7 +22,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your OpenAI API key',
     helpLink: 'https://platform.openai.com/api-keys',
     helpLinkText: 'OpenAI Platform',
-    validateKey: (key: string) => key.startsWith('sk-') && key.length >= 30,
+    validateKey: (key: string) => key.trim().length >= 20,
   },
   anthropic: {
     id: 'anthropic',
@@ -32,7 +32,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your Anthropic API key',
     helpLink: 'https://console.anthropic.com/settings/keys',
     helpLinkText: 'Anthropic Console',
-    validateKey: (key: string) => key.startsWith('sk-ant-') && key.length >= 30,
+    validateKey: (key: string) => key.trim().length >= 20,
   },
   openrouter: {
     id: 'openrouter',
@@ -42,7 +42,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
     placeholder: 'Enter your OpenRouter API key',
     helpLink: 'https://openrouter.ai/keys',
     helpLinkText: 'OpenRouter Dashboard',
-    validateKey: (key: string) => key.startsWith('sk-or-') && key.length >= 30,
+    validateKey: (key: string) => key.trim().length >= 20,
   },
   custom: {
     id: 'custom',


### PR DESCRIPTION
## Problem

Issue #41: new Google AI Studio API keys (~53 chars) are rejected by the extension.

The Gemini validator used a hardcoded prefix check:

\`\`\`ts
validateKey: (key) => key.startsWith('AI') && key.length >= 30
\`\`\`

Google now issues keys that don't start with \`AI\`, so the prefix gate rejects valid keys. The reporter saw "53 characters" as the difference, but the prefix is what actually fails.

## Why relax it for all providers

This \`validateKey\` is only a cheap client-side format sniff. The authoritative validation already happens by calling the provider API to fetch models (see \`handleApiKeySave.ts\` — "Fetching models validates the key implicitly"). Hardcoding each vendor's current key prefix just guarantees breakage every time a vendor changes their format.

## Change

Drop the hardcoded prefixes for all four real providers (Google, OpenAI, Anthropic, OpenRouter) and keep a minimal sanity floor:

\`\`\`ts
validateKey: (key) => key.trim().length >= 20
\`\`\`

\`custom\` (optional key) and \`EMPTY_SERVICE\` (null fallback) are intentionally unchanged.

## Testing

- Verified the validator logic against representative key shapes (old 39-char \`AIza...\`, new 53-char no-prefix, junk, empty, boundary lengths) — all behave correctly.
- Confirmed end-to-end in the loaded extension with a real new API key: it now passes the format gate and authenticates.
- \`npm run build\` passes (tsc clean).

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)