### PR TITLE
Organize: batching for large/free-tier collections, honest progress, retries, duplicate cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ MarkMind uses AI to understand what you're saving and automatically organizes yo
 ### Key Features
 
 - **Smart Organization** - AI analyzes page content and suggests the best folder
-- **Bulk Processing** - Organize hundreds of bookmarks at once
+- **Bulk Processing** - Organize hundreds (or thousands) of bookmarks at once
+- **Handles Loose Bookmarks** - Bookmarks scattered outside folders are organized too, not just ones already in folders
+- **Duplicate Cleanup** - Finds bookmarks saved more than once and lets you remove the extras
+- **Live Progress** - See exactly how many bookmarks have been organized while it works
 - **Multiple AI Providers** - Google Gemini, OpenAI, Anthropic, or OpenRouter
 - **Privacy First** - Your bookmarks stay in your browser, only titles/URLs are sent to the AI
 - **Review Before Apply** - Always review and approve changes before they happen
@@ -92,8 +95,16 @@ MarkMind uses AI to understand what you're saving and automatically organizes yo
 
 1. Click the MarkMind icon → Organize tab
 2. Scan your bookmarks
-3. Select bookmarks to organize
-4. Review AI suggestions and apply
+3. (Optional) Review and remove any duplicate bookmarks found
+4. Select bookmarks to organize — loose bookmarks outside folders are included
+5. Review AI suggestions and apply
+
+### What to Expect
+
+- **How long does it take?** Usually seconds to a minute. Large collections are processed in several passes and can take a few minutes — you'll see a live "Organized X of Y bookmarks" count and a timer the whole time, so you always know it's working. Feel free to close the popup; it keeps going in the background.
+- **Free AI providers:** Free tiers (e.g. free Gemini models) have stricter limits and can be briefly unavailable. MarkMind automatically retries, sizes the work to fit your model, and tells you in plain language if something needs another try. If a large run struggles, organizing in smaller groups helps.
+- **Scattered bookmarks:** Bookmarks that aren't in any folder are picked up and organized along with the rest.
+- **Duplicates:** After scanning, MarkMind shows any bookmarks saved more than once and lets you remove the extras (it always keeps one copy).
 
 ## Supported AI Providers
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint src/",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "keywords": [
     "chrome-extension",
@@ -32,6 +33,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^4.1.9"
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -23,7 +23,10 @@ const handleStartOrganize = async (payload: StartOrganizePayload): Promise<void>
     payload.bookmarks,
     payload.folderTree,
     payload.pathToIdMap,
-    payload.maxOutputTokens
+    payload.maxOutputTokens,
+    (processedCount, totalCount) => {
+      notifyPopup('ORGANIZE_PROGRESS', { processedCount, totalCount });
+    }
   );
 
   // Merge AI results into the existing session (or a fresh one if storage read fails)

--- a/src/background.ts
+++ b/src/background.ts
@@ -49,6 +49,15 @@ const handleStartOrganize = async (payload: StartOrganizePayload): Promise<void>
     defaultParentId: payload.defaultParentId,
   };
 
+  // Re-check right before persisting: the user may have cancelled while we were
+  // preparing the result. Without this, a cancel that lands in the small window
+  // after the read above would be overwritten and resurrected on next open.
+  const latestSession = await loadOrganizeSession();
+  if (latestSession && latestSession.status !== 'organizing') {
+    chrome.alarms.clear(KEEPALIVE_ALARM_NAME);
+    return;
+  }
+
   await saveOrganizeSession(completedSession);
   chrome.alarms.clear(KEEPALIVE_ALARM_NAME);
 

--- a/src/components/OrganizeDuplicates/OrganizeDuplicates.css
+++ b/src/components/OrganizeDuplicates/OrganizeDuplicates.css
@@ -1,0 +1,105 @@
+.organize-duplicates {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--spacing-2xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.organize-duplicates-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.organize-duplicates-subtitle {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
+}
+
+.organize-duplicates-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.organize-duplicates-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.organize-duplicates-url {
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.organize-duplicates-copies {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.organize-duplicates-copy {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.organize-duplicates-tag-keep,
+.organize-duplicates-tag-remove {
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 1px var(--spacing-xs);
+  border-radius: var(--radius-sm);
+}
+
+.organize-duplicates-tag-keep {
+  color: var(--color-success);
+  background-color: var(--color-success-bg);
+}
+
+.organize-duplicates-tag-remove {
+  color: var(--color-warning);
+  background-color: var(--color-warning-bg);
+}
+
+.organize-duplicates-location {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.organize-duplicates-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.organize-duplicates-confirm-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
+.organize-duplicates-confirm-actions {
+  display: flex;
+  gap: var(--spacing-md);
+}

--- a/src/components/OrganizeDuplicates/OrganizeDuplicates.css
+++ b/src/components/OrganizeDuplicates/OrganizeDuplicates.css
@@ -49,42 +49,45 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2xs);
-  list-style: none;
-  margin: 0;
-  padding: 0;
 }
 
 .organize-duplicates-copy {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  width: 100%;
+  text-align: left;
+  padding: var(--spacing-2xs) var(--spacing-xs);
+  border-radius: var(--radius-sm);
   font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
 }
 
-.organize-duplicates-tag-keep,
-.organize-duplicates-tag-remove {
-  flex-shrink: 0;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  padding: 1px var(--spacing-xs);
-  border-radius: var(--radius-sm);
+.organize-duplicates-copy:hover {
+  background-color: var(--color-surface);
 }
 
-.organize-duplicates-tag-keep {
-  color: var(--color-success);
-  background-color: var(--color-success-bg);
-}
-
-.organize-duplicates-tag-remove {
-  color: var(--color-warning);
-  background-color: var(--color-warning-bg);
+.organize-duplicates-copy.is-keeper {
+  color: var(--color-text);
 }
 
 .organize-duplicates-location {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.organize-duplicates-keep-tag {
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-success);
+  background-color: var(--color-success-bg);
+  padding: 1px var(--spacing-xs);
+  border-radius: var(--radius-sm);
 }
 
 .organize-duplicates-confirm {

--- a/src/components/OrganizeDuplicates/OrganizeDuplicates.tsx
+++ b/src/components/OrganizeDuplicates/OrganizeDuplicates.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+import { type DuplicateGroup } from '../../types/organize';
+import { countRemovableDuplicates, getDuplicateIdsToRemove } from '../../utils/duplicates';
+import Button from '../Button/Button';
+import './OrganizeDuplicates.css';
+
+interface OrganizeDuplicatesProps {
+  groups: DuplicateGroup[];
+  onRemove: (bookmarkIdsToRemove: string[]) => Promise<void>;
+}
+
+const OrganizeDuplicates = ({ groups, onRemove }: OrganizeDuplicatesProps) => {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const removableCount = countRemovableDuplicates(groups);
+
+  const handleRemove = useCallback(async (): Promise<void> => {
+    setIsRemoving(true);
+    try {
+      await onRemove(getDuplicateIdsToRemove(groups));
+    } finally {
+      setIsRemoving(false);
+      setIsConfirming(false);
+    }
+  }, [groups, onRemove]);
+
+  if (groups.length === 0) return null;
+
+  const bookmarkWord = removableCount === 1 ? 'bookmark' : 'bookmarks';
+
+  return (
+    <div className="organize-duplicates">
+      <p className="organize-duplicates-title">
+        {removableCount} duplicate {bookmarkWord} found
+      </p>
+      <p className="organize-duplicates-subtitle">
+        One copy of each is kept; the rest are removed.
+      </p>
+
+      <div className="organize-duplicates-list">
+        {groups.map(group => (
+          <div key={group.url} className="organize-duplicates-group">
+            <p className="organize-duplicates-url" title={group.url}>{group.url}</p>
+            <ul className="organize-duplicates-copies">
+              {group.bookmarks.map((bookmark, index) => (
+                <li key={bookmark.id} className="organize-duplicates-copy">
+                  <span className={index === 0 ? 'organize-duplicates-tag-keep' : 'organize-duplicates-tag-remove'}>
+                    {index === 0 ? 'Keep' : 'Remove'}
+                  </span>
+                  <span className="organize-duplicates-location">
+                    {bookmark.currentFolderPath || 'Root'} — {bookmark.title || 'Untitled'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {isConfirming ? (
+        <div className="organize-duplicates-confirm">
+          <p className="organize-duplicates-confirm-text">
+            Delete {removableCount} {bookmarkWord}? This can't be undone.
+          </p>
+          <div className="organize-duplicates-confirm-actions">
+            <Button onClick={() => setIsConfirming(false)} disabled={isRemoving}>
+              Cancel
+            </Button>
+            <Button variant="danger" onClick={handleRemove} disabled={isRemoving}>
+              {isRemoving ? 'Removing...' : `Yes, remove ${removableCount}`}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button onClick={() => setIsConfirming(true)} fullWidth>
+          Remove {removableCount} duplicate {bookmarkWord}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default OrganizeDuplicates;

--- a/src/components/OrganizeDuplicates/OrganizeDuplicates.tsx
+++ b/src/components/OrganizeDuplicates/OrganizeDuplicates.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { type DuplicateGroup } from '../../types/organize';
-import { countRemovableDuplicates, getDuplicateIdsToRemove } from '../../utils/duplicates';
+import OrganizeCheckbox from '../OrganizeCheckbox/OrganizeCheckbox';
 import Button from '../Button/Button';
 import './OrganizeDuplicates.css';
 
@@ -10,20 +10,36 @@ interface OrganizeDuplicatesProps {
 }
 
 const OrganizeDuplicates = ({ groups, onRemove }: OrganizeDuplicatesProps) => {
+  // Which copy to keep per group, keyed by URL. Defaults to the first copy;
+  // missing keys fall back so re-scans with new groups still work.
+  const [keeperByUrl, setKeeperByUrl] = useState<Record<string, string>>({});
   const [isConfirming, setIsConfirming] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
 
-  const removableCount = countRemovableDuplicates(groups);
+  const getKeeperId = (group: DuplicateGroup): string =>
+    keeperByUrl[group.url] ?? group.bookmarks[0].id;
+
+  const setKeeperId = (url: string, bookmarkId: string): void => {
+    setKeeperByUrl(previous => ({ ...previous, [url]: bookmarkId }));
+  };
+
+  // Everything except the chosen keeper in each group.
+  const idsToRemove = groups.flatMap(group =>
+    group.bookmarks
+      .filter(bookmark => bookmark.id !== getKeeperId(group))
+      .map(bookmark => bookmark.id)
+  );
+  const removableCount = idsToRemove.length;
 
   const handleRemove = useCallback(async (): Promise<void> => {
     setIsRemoving(true);
     try {
-      await onRemove(getDuplicateIdsToRemove(groups));
+      await onRemove(idsToRemove);
     } finally {
       setIsRemoving(false);
       setIsConfirming(false);
     }
-  }, [groups, onRemove]);
+  }, [idsToRemove, onRemove]);
 
   if (groups.length === 0) return null;
 
@@ -32,30 +48,41 @@ const OrganizeDuplicates = ({ groups, onRemove }: OrganizeDuplicatesProps) => {
   return (
     <div className="organize-duplicates">
       <p className="organize-duplicates-title">
-        {removableCount} duplicate {bookmarkWord} found
+        {removableCount} duplicate {bookmarkWord} to remove
       </p>
       <p className="organize-duplicates-subtitle">
-        One copy of each is kept; the rest are removed.
+        Pick the copy to keep in each group — the others are removed.
       </p>
 
       <div className="organize-duplicates-list">
-        {groups.map(group => (
-          <div key={group.url} className="organize-duplicates-group">
-            <p className="organize-duplicates-url" title={group.url}>{group.url}</p>
-            <ul className="organize-duplicates-copies">
-              {group.bookmarks.map((bookmark, index) => (
-                <li key={bookmark.id} className="organize-duplicates-copy">
-                  <span className={index === 0 ? 'organize-duplicates-tag-keep' : 'organize-duplicates-tag-remove'}>
-                    {index === 0 ? 'Keep' : 'Remove'}
-                  </span>
-                  <span className="organize-duplicates-location">
-                    {bookmark.currentFolderPath || 'Root'} — {bookmark.title || 'Untitled'}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
+        {groups.map(group => {
+          const keeperId = getKeeperId(group);
+          return (
+            <div key={group.url} className="organize-duplicates-group">
+              <p className="organize-duplicates-url" title={group.url}>{group.url}</p>
+              <div className="organize-duplicates-copies">
+                {group.bookmarks.map(bookmark => {
+                  const isKeeper = bookmark.id === keeperId;
+                  return (
+                    <Button
+                      key={bookmark.id}
+                      variant="unstyled"
+                      className={`organize-duplicates-copy${isKeeper ? ' is-keeper' : ''}`}
+                      onClick={() => setKeeperId(group.url, bookmark.id)}
+                      title={isKeeper ? 'Kept' : 'Click to keep this copy'}
+                    >
+                      <OrganizeCheckbox state={isKeeper ? 'full' : 'empty'} />
+                      <span className="organize-duplicates-location">
+                        {bookmark.currentFolderPath || 'Root'} — {bookmark.title || 'Untitled'}
+                      </span>
+                      {isKeeper && <span className="organize-duplicates-keep-tag">keep</span>}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       {isConfirming ? (
@@ -73,7 +100,7 @@ const OrganizeDuplicates = ({ groups, onRemove }: OrganizeDuplicatesProps) => {
           </div>
         </div>
       ) : (
-        <Button onClick={() => setIsConfirming(true)} fullWidth>
+        <Button onClick={() => setIsConfirming(true)} fullWidth disabled={removableCount === 0}>
           Remove {removableCount} duplicate {bookmarkWord}
         </Button>
       )}

--- a/src/components/OrganizeScan/OrganizeScan.css
+++ b/src/components/OrganizeScan/OrganizeScan.css
@@ -90,3 +90,14 @@
   max-height: 340px;
   overflow-y: auto;
 }
+
+/* Plain-language heads-up for large selections */
+.organize-scan-heads-up {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
+}

--- a/src/components/OrganizeScan/OrganizeScan.tsx
+++ b/src/components/OrganizeScan/OrganizeScan.tsx
@@ -2,8 +2,10 @@ import { useState, useCallback, useMemo } from 'react';
 import { type OrganizeSession } from '../../types/organize';
 import { type BookmarkStats } from '../../types/bookmarks';
 import { buildFolderTree } from '../../utils/bookmarkScanner';
+import { findDuplicateBookmarks, countRemovableDuplicates } from '../../utils/duplicates';
 import { FolderIcon, SpinnerIcon, RefreshIcon } from '../icons/Icons';
 import OrganizeStatusView from '../OrganizeStatusView/OrganizeStatusView';
+import OrganizeDuplicates from '../OrganizeDuplicates/OrganizeDuplicates';
 import TreeNode from '../TreeNode/TreeNode';
 import Button from '../Button/Button';
 import './OrganizeScan.css';
@@ -16,6 +18,7 @@ interface OrganizeScanProps {
   onSelectAll: () => void;
   onDeselectAll: () => void;
   onStartPlanning: () => void;
+  onRemoveDuplicates: (bookmarkIdsToRemove: string[]) => Promise<void>;
 }
 
 const OrganizeScan = ({
@@ -26,8 +29,10 @@ const OrganizeScan = ({
   onSelectAll,
   onDeselectAll,
   onStartPlanning,
+  onRemoveDuplicates,
 }: OrganizeScanProps) => {
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [showDuplicates, setShowDuplicates] = useState(false);
 
   const handleToggleExpand = useCallback((nodePath: string) => {
     setExpandedPaths(previous => {
@@ -52,6 +57,16 @@ const OrganizeScan = ({
   );
 
   const selectedCount = selectedSet.size;
+
+  const duplicateGroups = useMemo(
+    () => findDuplicateBookmarks(session.allBookmarks),
+    [session.allBookmarks]
+  );
+  const duplicateCount = countRemovableDuplicates(duplicateGroups);
+
+  // Many bookmarks means several passes — set expectations up front, in plain terms.
+  const LARGE_SELECTION_THRESHOLD = 200;
+  const isLargeSelection = selectedCount >= LARGE_SELECTION_THRESHOLD;
 
   if (session.status === 'scanning') {
     return (
@@ -87,6 +102,20 @@ const OrganizeScan = ({
             <Button onClick={onDeselectAll}>Deselect All</Button>
           </div>
 
+          {duplicateCount > 0 && (
+            <Button
+              variant="ghost"
+              fullWidth
+              onClick={() => setShowDuplicates(previous => !previous)}
+            >
+              {showDuplicates ? 'Hide' : 'Review'} {duplicateCount} duplicate {duplicateCount === 1 ? 'bookmark' : 'bookmarks'}
+            </Button>
+          )}
+
+          {showDuplicates && duplicateCount > 0 && (
+            <OrganizeDuplicates groups={duplicateGroups} onRemove={onRemoveDuplicates} />
+          )}
+
           <div className="organize-scan-folder-list">
             {folderTree.children.map(topLevelNode => (
               <TreeNode
@@ -101,6 +130,12 @@ const OrganizeScan = ({
             ))}
           </div>
         </div>
+
+        {isLargeSelection && (
+          <p className="organize-scan-heads-up">
+            You've selected {selectedCount.toLocaleString()} bookmarks. Organizing this many can take a few minutes — you can also do it in smaller groups.
+          </p>
+        )}
 
         <Button
           variant="primary"

--- a/src/components/tabs/OrganizeTab.tsx
+++ b/src/components/tabs/OrganizeTab.tsx
@@ -1,4 +1,5 @@
 import { useBulkOrganize } from '../../hooks/useBulkOrganize';
+import { formatElapsedTime } from '../../utils/helpers';
 import { SpinnerIcon } from '../icons/Icons';
 import Button from '../Button/Button';
 import OrganizeScan from '../OrganizeScan/OrganizeScan';
@@ -13,7 +14,10 @@ const OrganizeTab = () => {
     bookmarkStats,
     statusMessage,
     statusType,
+    elapsedSeconds,
+    organizeProgress,
     handleStartScan,
+    handleRemoveDuplicates,
     handleToggleBookmarks,
     handleSelectAll,
     handleDeselectAll,
@@ -41,23 +45,31 @@ const OrganizeTab = () => {
           onSelectAll={handleSelectAll}
           onDeselectAll={handleDeselectAll}
           onStartPlanning={handleStartOrganizing}
+          onRemoveDuplicates={handleRemoveDuplicates}
         />
       );
 
-    case 'organizing':
+    case 'organizing': {
+      // Once a pass completes we have a real count to show — more honest than the
+      // rotating messages, which carry the wait until the first pass finishes.
+      const organizingTitle = organizeProgress
+        ? `Organized ${organizeProgress.processed.toLocaleString()} of ${organizeProgress.total.toLocaleString()} bookmarks...`
+        : statusType === 'loading' && statusMessage
+          ? statusMessage
+          : 'Analyzing your bookmarks...';
+
       return (
         <OrganizeStatusView
           icon={<SpinnerIcon width={24} height={24} />}
-          title={statusType === 'loading' && statusMessage
-            ? statusMessage
-            : 'Analyzing your bookmarks...'}
-          description="Feel free to close this popup — MarkMind keeps organizing in the background. Come back anytime to check progress."
+          title={organizingTitle}
+          description={`Working for ${formatElapsedTime(elapsedSeconds)} — feel free to close this popup. MarkMind keeps organizing in the background; come back anytime to check progress.`}
         >
           <Button onClick={handleCancelOrganizing} fullWidth>
             Cancel
           </Button>
         </OrganizeStatusView>
       );
+    }
 
     case 'reviewing_assignments':
       return (

--- a/src/config/loadingMessages.ts
+++ b/src/config/loadingMessages.ts
@@ -1,19 +1,12 @@
-export const LOADING_MESSAGES: string[] = [
-  'MarkMind is helping you...',
-  'Finding the perfect folder...',
-  'Almost there!',
-  "You're on the right path!",
-  'Organizing your world...',
-  'AI is thinking...',
-  'Just a moment...',
-  'Analyzing your page...',
+// Status messages shown while the AI organizes bookmarks.
+// {bookmarks} is replaced with the real count (e.g. "1,240 bookmarks").
+// Templates are DATA only — substitution lives in utils/loadingMessages.ts.
+export const LOADING_MESSAGE_TEMPLATES: string[] = [
+  'Sending your {bookmarks} for analysis...',
+  'MarkMind is reading your {bookmarks}...',
+  'MarkMind is choosing the best folders...',
+  'Analyzing {bookmarks}...',
+  'MarkMind is thinking this through — larger collections take longer...',
   'Smart sorting in progress...',
+  'Still working — organizing your {bookmarks}...',
 ];
-
-export const getNextLoadingMessage = (currentIndex: number): { message: string; nextIndex: number } => {
-  const nextIndex = (currentIndex + 1) % LOADING_MESSAGES.length;
-  return {
-    message: LOADING_MESSAGES[nextIndex],
-    nextIndex,
-  };
-};

--- a/src/hooks/useBulkOrganize/types.ts
+++ b/src/hooks/useBulkOrganize/types.ts
@@ -7,7 +7,10 @@ export interface UseBulkOrganizeReturn {
   bookmarkStats: BookmarkStats | null;
   statusMessage: string;
   statusType: StatusType;
+  elapsedSeconds: number;
+  organizeProgress: { processed: number; total: number } | null;
   handleStartScan: () => Promise<void>;
+  handleRemoveDuplicates: (bookmarkIdsToRemove: string[]) => Promise<void>;
   handleToggleBookmarks: (bookmarkIds: string[]) => void;
   handleSelectAll: () => void;
   handleDeselectAll: () => void;

--- a/src/hooks/useBulkOrganize/useBulkOrganize.ts
+++ b/src/hooks/useBulkOrganize/useBulkOrganize.ts
@@ -1,22 +1,25 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { SELECTED_SERVICE_STORAGE_KEY, SELECTED_MODEL_STORAGE_KEY } from '../../config/services';
-import { LOADING_MESSAGES, getNextLoadingMessage } from '../../config/loadingMessages';
+import { buildLoadingMessage, getNextLoadingMessageIndex } from '../../utils/loadingMessages';
 import { type StatusType } from '../../types/common';
 import { type OrganizeSession, type BulkOrganizeResult } from '../../types/organize';
 import { getBookmarkStats, flattenAllBookmarks } from '../../utils/bookmarkScanner';
 import { getFolderDataForAI, buildFullIdToPathMapFromTree } from '../../utils/folders';
 import { saveOrganizeSession, loadOrganizeSession, clearOrganizeSession, getInitialSession } from '../../services/organizeSession';
-import { moveBookmark, createFolderPath } from '../../services/bookmarks';
+import { moveBookmark, createFolderPath, removeBookmark } from '../../services/bookmarks';
 import { getSelectedMaxOutputTokens } from '../../services/selectedState';
 import { type UseBulkOrganizeReturn } from './types';
 
-const LOADING_MESSAGE_INTERVAL_MS = 2000;
+const STATUS_TICK_MS = 1000;
+const MESSAGE_ROTATE_EVERY_TICKS = 2;
 const DEBOUNCE_SAVE_MS = 500;
 
 export const useBulkOrganize = (): UseBulkOrganizeReturn => {
   const [session, setSession] = useState<OrganizeSession>(getInitialSession());
   const [statusMessage, setStatusMessage] = useState('');
   const [statusType, setStatusType] = useState<StatusType>('default');
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [organizeProgress, setOrganizeProgress] = useState<{ processed: number; total: number } | null>(null);
 
   // Ref always holds the latest session — avoids stale closures in handlers
   // and race conditions when multiple updates happen before React re-renders
@@ -34,19 +37,35 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     }
     setStatusMessage('');
     setStatusType('default');
+    setElapsedSeconds(0);
+    setOrganizeProgress(null);
   }, []);
 
-  const startLoadingMessages = useCallback((): void => {
-    loadingMessageIndexRef.current = 0;
-    setStatusMessage(LOADING_MESSAGES[0]);
-    setStatusType('loading');
+  // Shows rotating status built from the real provider + bookmark count, plus a
+  // live elapsed timer (derived from startedAt so it stays accurate across popup
+  // reopen). The AI runs as a single service-worker call, so there is no
+  // per-bookmark progress to report — this is the honest signal we can give.
+  const startLoadingMessages = useCallback(
+    (bookmarkCount: number, startedAt: number): void => {
+      loadingMessageIndexRef.current = 0;
+      setOrganizeProgress(null);
+      setStatusMessage(buildLoadingMessage(0, bookmarkCount));
+      setStatusType('loading');
+      setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
 
-    loadingMessageIntervalRef.current = setInterval(() => {
-      const { message, nextIndex } = getNextLoadingMessage(loadingMessageIndexRef.current);
-      loadingMessageIndexRef.current = nextIndex;
-      setStatusMessage(message);
-    }, LOADING_MESSAGE_INTERVAL_MS);
-  }, []);
+      let tickCount = 0;
+      loadingMessageIntervalRef.current = setInterval(() => {
+        tickCount += 1;
+        setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
+
+        if (tickCount % MESSAGE_ROTATE_EVERY_TICKS === 0) {
+          loadingMessageIndexRef.current = getNextLoadingMessageIndex(loadingMessageIndexRef.current);
+          setStatusMessage(buildLoadingMessage(loadingMessageIndexRef.current, bookmarkCount));
+        }
+      }, STATUS_TICK_MS);
+    },
+    []
+  );
 
   const debouncedSaveSession = useCallback((sessionToSave: OrganizeSession): void => {
     if (debouncedSaveRef.current) {
@@ -92,9 +111,12 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
 
         setSession(savedSession);
 
-        // AI call runs in service worker — show loading messages while waiting
+        // AI call runs in service worker — resume loading messages while waiting
         if (savedSession.status === 'organizing') {
-          startLoadingMessages();
+          startLoadingMessages(
+            savedSession.bookmarksToOrganize.length,
+            savedSession.startedAt ?? Date.now()
+          );
         }
       } catch (error) {
         console.error('Error resuming organize session:', error);
@@ -121,6 +143,11 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     const handleMessage = (message: { type: string; payload?: unknown }): void => {
       // Ignore service worker responses if the user already cancelled
       if (sessionRef.current.status !== 'organizing') return;
+
+      if (message.type === 'ORGANIZE_PROGRESS') {
+        const payload = message.payload as { processedCount: number; totalCount: number };
+        setOrganizeProgress({ processed: payload.processedCount, total: payload.totalCount });
+      }
 
       if (message.type === 'ORGANIZE_COMPLETE') {
         const payload = message.payload as { result: BulkOrganizeResult };
@@ -215,6 +242,18 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     }
   }, [updateSession]);
 
+  const handleRemoveDuplicates = useCallback(async (bookmarkIdsToRemove: string[]): Promise<void> => {
+    for (const bookmarkId of bookmarkIdsToRemove) {
+      try {
+        await removeBookmark(bookmarkId);
+      } catch (error) {
+        console.error('Error removing duplicate bookmark:', bookmarkId, error);
+      }
+    }
+    // Re-scan so the bookmark list and selection reflect the removals.
+    await handleStartScan();
+  }, [handleStartScan]);
+
   const handleToggleBookmarks = useCallback((bookmarkIds: string[]): void => {
     setSession(previousSession => {
       const currentSelected = new Set(previousSession.selectedBookmarkIds ?? []);
@@ -278,13 +317,15 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
         return;
       }
 
+      const startedAt = Date.now();
       await updateSession({
         status: 'organizing',
         bookmarksToOrganize,
         serviceId,
+        startedAt,
       });
 
-      startLoadingMessages();
+      startLoadingMessages(bookmarksToOrganize.length, startedAt);
 
       chrome.runtime.sendMessage({
         type: 'START_ORGANIZE',
@@ -444,7 +485,10 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
     bookmarkStats,
     statusMessage,
     statusType,
+    elapsedSeconds,
+    organizeProgress,
     handleStartScan,
+    handleRemoveDuplicates,
     handleToggleBookmarks,
     handleSelectAll,
     handleDeselectAll,

--- a/src/hooks/useBulkOrganize/useBulkOrganize.ts
+++ b/src/hooks/useBulkOrganize/useBulkOrganize.ts
@@ -243,13 +243,17 @@ export const useBulkOrganize = (): UseBulkOrganizeReturn => {
   }, [updateSession]);
 
   const handleRemoveDuplicates = useCallback(async (bookmarkIdsToRemove: string[]): Promise<void> => {
-    for (const bookmarkId of bookmarkIdsToRemove) {
-      try {
-        await removeBookmark(bookmarkId);
-      } catch (error) {
-        console.error('Error removing duplicate bookmark:', bookmarkId, error);
-      }
-    }
+    // Remove in parallel — deletions target distinct bookmark nodes and don't
+    // depend on each other. Per-item catch so one failure doesn't abort the rest.
+    await Promise.all(
+      bookmarkIdsToRemove.map(async (bookmarkId) => {
+        try {
+          await removeBookmark(bookmarkId);
+        } catch (error) {
+          console.error('Error removing duplicate bookmark:', bookmarkId, error);
+        }
+      })
+    );
     // Re-scan so the bookmark list and selection reflect the removals.
     await handleStartScan();
   }, [handleStartScan]);

--- a/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
+++ b/src/hooks/useOrganizeBookmark/useOrganizeBookmark.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { LOADING_MESSAGES, getNextLoadingMessage } from '../../config/loadingMessages';
+import { buildLoadingMessage, getNextLoadingMessageIndex } from '../../utils/loadingMessages';
 import { type StatusType } from '../../types/common';
 import { type FolderDataForAI, type PendingSuggestion } from '../../types/bookmarks';
 import { type PageMetadata } from '../../types/pages';
@@ -77,14 +77,16 @@ export const useOrganizeBookmark = (): UseOrganizeBookmarkReturn => {
   }, []);
 
   const startLoadingMessages = useCallback((): void => {
+    // Single-page organize handles exactly one bookmark.
+    const SINGLE_BOOKMARK_COUNT = 1;
+
     loadingMessageIndexRef.current = 0;
-    setStatusMessage(LOADING_MESSAGES[0]);
+    setStatusMessage(buildLoadingMessage(0, SINGLE_BOOKMARK_COUNT));
     setStatusType('loading');
 
     loadingMessageIntervalRef.current = setInterval(() => {
-      const { message, nextIndex } = getNextLoadingMessage(loadingMessageIndexRef.current);
-      loadingMessageIndexRef.current = nextIndex;
-      setStatusMessage(message);
+      loadingMessageIndexRef.current = getNextLoadingMessageIndex(loadingMessageIndexRef.current);
+      setStatusMessage(buildLoadingMessage(loadingMessageIndexRef.current, SINGLE_BOOKMARK_COUNT));
     }, LOADING_MESSAGE_INTERVAL_MS);
   }, []);
 

--- a/src/services/ai/bulkOrganize.test.ts
+++ b/src/services/ai/bulkOrganize.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { computeBatchSize } from './bulkOrganize';
+
+describe('computeBatchSize', () => {
+  it('uses a safe fallback when the model limit is unknown', () => {
+    // 4096 * 0.6 / 70 = 35.1 -> 35
+    expect(computeBatchSize(undefined)).toBe(35);
+  });
+
+  it('clamps tiny models up to the minimum batch size', () => {
+    // 1000 * 0.6 / 70 = 8.5 -> clamped to 25
+    expect(computeBatchSize(1000)).toBe(25);
+  });
+
+  it('clamps huge models down to the maximum batch size', () => {
+    expect(computeBatchSize(1_000_000)).toBe(150);
+  });
+
+  it('scales with a mid-range model output limit', () => {
+    // 8192 * 0.6 / 70 = 70.2 -> 70
+    expect(computeBatchSize(8192)).toBe(70);
+  });
+});

--- a/src/services/ai/bulkOrganize.ts
+++ b/src/services/ai/bulkOrganize.ts
@@ -1,10 +1,50 @@
-import { type FolderPlan, type BookmarkAssignment, type CompactBookmark, type BulkOrganizeResult } from '../../types/organize';
+import { type FolderPlan, type ProposedFolder, type BookmarkAssignment, type CompactBookmark, type BulkOrganizeResult } from '../../types/organize';
 import { type FolderPathMap } from '../../types/bookmarks';
 import { BULK_ORGANIZE_SYSTEM_PROMPT, buildBulkOrganizeUserPrompt } from './bulkPrompt';
 import { getApiKey, callProvider } from './providerUtils';
 import { findFolderIdByAIPath } from '../../utils/folders';
+import { chunkArray, isRetryableError } from '../../utils/helpers';
+import { parseJsonLoose } from '../../utils/json';
 import { type ModelOption } from '../../types/services';
 import { MODELS_CACHE_KEY_PREFIX } from '../../config/services';
+
+// Batch size is derived from the model's output token budget — the JSON of
+// assignments is what overflows small/free models, so we size each pass to fit.
+const TOKENS_PER_ASSIGNMENT = 70;
+const OUTPUT_SAFETY_FACTOR = 0.6;
+const MIN_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 150;
+const FALLBACK_MAX_OUTPUT_TOKENS = 4096;
+
+export const computeBatchSize = (maxOutputTokens?: number): number => {
+  const budget = (maxOutputTokens ?? FALLBACK_MAX_OUTPUT_TOKENS) * OUTPUT_SAFETY_FACTOR;
+  const estimated = Math.floor(budget / TOKENS_PER_ASSIGNMENT);
+  return Math.min(MAX_BATCH_SIZE, Math.max(MIN_BATCH_SIZE, estimated));
+};
+
+export type OrganizeProgressCallback = (organizedCount: number, totalCount: number) => void;
+
+// Transient failures (overload/rate-limit/timeout) are retried with exponential
+// backoff so free tiers that 503 under load still succeed.
+const MAX_BATCH_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1500;
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, milliseconds));
+
+const withRetry = async <T>(operation: () => Promise<T>): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= MAX_BATCH_RETRIES; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableError(error) || attempt === MAX_BATCH_RETRIES) throw error;
+      await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+  }
+  throw lastError;
+};
 
 const lookupMaxOutputTokens = async (serviceId: string, modelId: string): Promise<number | undefined> => {
   const cacheKey = `${MODELS_CACHE_KEY_PREFIX}${serviceId}`;
@@ -33,7 +73,11 @@ const parseBulkOrganizeResponse = (
   const jsonText = extractJsonFromResponse(responseText);
 
   try {
-    const parsed = JSON.parse(jsonText);
+    const parsed = parseJsonLoose(jsonText) as {
+      folders?: unknown;
+      assignments?: unknown;
+      summary?: unknown;
+    };
 
     if (typeof parsed !== 'object' || parsed === null || !Array.isArray(parsed.folders)) {
       throw new Error('Response missing "folders" array');
@@ -83,9 +127,40 @@ const parseBulkOrganizeResponse = (
 
     return { folderPlan, assignments };
   } catch (error) {
-    console.error('Failed to parse bulk organize response:', error, '\nResponse:', responseText);
-    throw new Error('Failed to parse AI response');
+    // Log the failure and response size only — not the body, which can contain user bookmark data.
+    console.error('Failed to parse bulk organize response:', error, `(response length: ${responseText.length})`);
+    throw new Error("The AI's response wasn't readable. Please try again.");
   }
+};
+
+// Runs one AI pass over a single batch of bookmarks.
+const organizeBatch = async (
+  serviceId: string,
+  modelId: string,
+  apiKey: string,
+  batch: CompactBookmark[],
+  folderTree: string,
+  pathToIdMap: FolderPathMap,
+  proposedFolders: ProposedFolder[],
+  maxOutputTokens?: number
+): Promise<BulkOrganizeResult> => {
+  const userPrompt = buildBulkOrganizeUserPrompt(
+    batch,
+    folderTree,
+    proposedFolders.map(folder => ({ path: folder.path, description: folder.description }))
+  );
+
+  const responseText = await callProvider(
+    serviceId,
+    apiKey,
+    BULK_ORGANIZE_SYSTEM_PROMPT,
+    userPrompt,
+    modelId,
+    maxOutputTokens,
+    batch.length
+  );
+
+  return parseBulkOrganizeResponse(responseText, batch, pathToIdMap);
 };
 
 export const organizeBookmarks = async (
@@ -94,21 +169,77 @@ export const organizeBookmarks = async (
   bookmarks: CompactBookmark[],
   folderTree: string,
   pathToIdMap: FolderPathMap,
-  maxOutputTokens?: number
+  maxOutputTokens?: number,
+  onProgress?: OrganizeProgressCallback
 ): Promise<BulkOrganizeResult> => {
   const resolvedTokens = maxOutputTokens ?? await lookupMaxOutputTokens(serviceId, modelId);
   const apiKey = await getApiKey(serviceId);
-  const userPrompt = buildBulkOrganizeUserPrompt(bookmarks, folderTree);
 
-  const responseText = await callProvider(
-    serviceId,
-    apiKey,
-    BULK_ORGANIZE_SYSTEM_PROMPT,
-    userPrompt,
-    modelId,
-    resolvedTokens,
-    bookmarks.length
-  );
+  const batchSize = computeBatchSize(resolvedTokens);
+  const batches = chunkArray(bookmarks, batchSize);
 
-  return parseBulkOrganizeResponse(responseText, bookmarks, pathToIdMap);
+  // Sequential passes share an accumulating folder plan so later batches reuse
+  // the folders earlier ones proposed (keeps the structure coherent).
+  const foldersByPath = new Map<string, ProposedFolder>();
+  const allAssignments: BookmarkAssignment[] = [];
+  const summaries: string[] = [];
+  let processedCount = 0;
+  let failedCount = 0;
+
+  for (const batch of batches) {
+    try {
+      const result = await withRetry(() =>
+        organizeBatch(
+          serviceId,
+          modelId,
+          apiKey,
+          batch,
+          folderTree,
+          pathToIdMap,
+          [...foldersByPath.values()],
+          resolvedTokens
+        )
+      );
+
+      for (const folder of result.folderPlan.folders) {
+        if (!foldersByPath.has(folder.path)) {
+          foldersByPath.set(folder.path, folder);
+        }
+      }
+      allAssignments.push(...result.assignments);
+      if (result.folderPlan.summary) {
+        summaries.push(result.folderPlan.summary);
+      }
+    } catch (error) {
+      // One failed pass shouldn't discard the bookmarks that already succeeded.
+      console.error('[BulkOrganize] Batch failed:', error);
+      failedCount += batch.length;
+
+      // If nothing has succeeded yet and this was the only/last batch, surface the real error.
+      if (allAssignments.length === 0 && processedCount + batch.length >= bookmarks.length) {
+        throw error;
+      }
+    }
+
+    processedCount += batch.length;
+    // Report bookmarks actually organized (not merely attempted) so the count is honest on failures.
+    onProgress?.(allAssignments.length, bookmarks.length);
+  }
+
+  if (allAssignments.length === 0) {
+    throw new Error('Could not organize any bookmarks. Please try again.');
+  }
+
+  // Single pass keeps the AI's own summary; multi-pass uses a neutral one.
+  let summary = batches.length === 1 ? (summaries[0] ?? '') : `Organized ${allAssignments.length} bookmarks into ${foldersByPath.size} folders.`;
+  if (failedCount > 0) {
+    summary += ` ${failedCount} couldn't be processed — run organize again to finish the rest.`;
+  }
+
+  const folderPlan: FolderPlan = {
+    folders: [...foldersByPath.values()],
+    summary,
+  };
+
+  return { folderPlan, assignments: allAssignments };
 };

--- a/src/services/ai/bulkOrganize.ts
+++ b/src/services/ai/bulkOrganize.ts
@@ -183,10 +183,10 @@ export const organizeBookmarks = async (
   const foldersByPath = new Map<string, ProposedFolder>();
   const allAssignments: BookmarkAssignment[] = [];
   const summaries: string[] = [];
-  let processedCount = 0;
   let failedCount = 0;
 
-  for (const batch of batches) {
+  for (let batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
+    const batch = batches[batchIndex];
     try {
       const result = await withRetry(() =>
         organizeBatch(
@@ -215,13 +215,12 @@ export const organizeBookmarks = async (
       console.error('[BulkOrganize] Batch failed:', error);
       failedCount += batch.length;
 
-      // If nothing has succeeded yet and this was the only/last batch, surface the real error.
-      if (allAssignments.length === 0 && processedCount + batch.length >= bookmarks.length) {
+      // If nothing has succeeded by the final batch, surface the real error.
+      if (allAssignments.length === 0 && batchIndex === batches.length - 1) {
         throw error;
       }
     }
 
-    processedCount += batch.length;
     // Report bookmarks actually organized (not merely attempted) so the count is honest on failures.
     onProgress?.(allAssignments.length, bookmarks.length);
   }

--- a/src/services/ai/bulkPrompt.ts
+++ b/src/services/ai/bulkPrompt.ts
@@ -53,9 +53,15 @@ PATH FORMAT RULES:
 - isNew = true ONLY for folders that need to be created
 - isNew = false for folders that already exist in the tree`;
 
+export interface ProposedFolderHint {
+  path: string;
+  description: string;
+}
+
 export const buildBulkOrganizeUserPrompt = (
   bookmarks: CompactBookmark[],
-  folderTree: string
+  folderTree: string,
+  proposedFolders: ProposedFolderHint[] = []
 ): string => {
   const bookmarkLines = bookmarks
     .map((bookmark, index) =>
@@ -69,11 +75,30 @@ export const buildBulkOrganizeUserPrompt = (
     '',
     '## CURRENT FOLDER STRUCTURE',
     folderTree,
+  ];
+
+  // When organizing in multiple passes, tell the model which folders earlier
+  // passes already proposed so it reuses the exact paths instead of creating
+  // near-duplicates (e.g. "Dev/Frontend" vs "Development/Frontend").
+  if (proposedFolders.length > 0) {
+    const proposedLines = proposedFolders
+      .map(folder => `- ${folder.path}${folder.description ? ` — ${folder.description}` : ''}`)
+      .join('\n');
+
+    parts.push(
+      '',
+      '## FOLDERS ALREADY PROPOSED IN THIS RUN',
+      'Reuse these EXACT paths whenever a bookmark fits — do not create near-duplicate folders:',
+      proposedLines
+    );
+  }
+
+  parts.push(
     '',
     'Analyze these bookmarks, propose the ideal folder structure, and assign each bookmark to the best folder.',
     'Reuse existing folders where appropriate. Only create new folders when necessary.',
-    'Return ONLY the JSON response.',
-  ];
+    'Return ONLY the JSON response.'
+  );
 
   return parts.join('\n');
 };

--- a/src/services/ai/providers/anthropic.ts
+++ b/src/services/ai/providers/anthropic.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError, TRUNCATED_RESPONSE_MESSAGE } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 export const fetchAnthropicModels = async (apiKey: string): Promise<ModelOption[]> => {
@@ -66,7 +66,7 @@ export const callAnthropic = async (
   const data = await response.json();
 
   if (data?.stop_reason === 'max_tokens') {
-    throw new Error('Anthropic response was truncated — the model ran out of output tokens. Please try again.');
+    throw new Error(TRUNCATED_RESPONSE_MESSAGE);
   }
 
   const text = data?.content?.[0]?.text;

--- a/src/services/ai/providers/custom.ts
+++ b/src/services/ai/providers/custom.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError, TRUNCATED_RESPONSE_MESSAGE } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const buildAuthHeaders = (apiKey: string): Record<string, string> => {
@@ -68,7 +68,7 @@ export const callCustom = async (
   const data = await response.json();
 
   if (data?.choices?.[0]?.finish_reason === 'length') {
-    throw new Error('Response was truncated — the model ran out of output tokens. Please try again.');
+    throw new Error(TRUNCATED_RESPONSE_MESSAGE);
   }
 
   const text = data?.choices?.[0]?.message?.content;

--- a/src/services/ai/providers/gemini.ts
+++ b/src/services/ai/providers/gemini.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError, TRUNCATED_RESPONSE_MESSAGE } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const GEMINI_MODEL_PREFIX = 'models/gemini-';
@@ -71,7 +71,7 @@ export const callGemini = async (
   const finishReason = data?.candidates?.[0]?.finishReason;
 
   if (finishReason === 'MAX_TOKENS') {
-    throw new Error('Gemini response was truncated — the model ran out of output tokens. Please try again.');
+    throw new Error(TRUNCATED_RESPONSE_MESSAGE);
   }
 
   const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;

--- a/src/services/ai/providers/openRouter.ts
+++ b/src/services/ai/providers/openRouter.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError, TRUNCATED_RESPONSE_MESSAGE } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const OPENROUTER_TEXT_PREFIXES = [
@@ -75,7 +75,7 @@ export const callOpenRouter = async (
   const data = await response.json();
 
   if (data?.choices?.[0]?.finish_reason === 'length') {
-    throw new Error('OpenRouter response was truncated — the model ran out of output tokens. Please try again.');
+    throw new Error(TRUNCATED_RESPONSE_MESSAGE);
   }
 
   const text = data?.choices?.[0]?.message?.content;

--- a/src/services/ai/providers/openai.ts
+++ b/src/services/ai/providers/openai.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError } from '../../../utils/helpers';
+import { fetchWithTimeout, getAiTimeoutMs, throwApiResponseError, TRUNCATED_RESPONSE_MESSAGE } from '../../../utils/helpers';
 import { type ModelOption } from '../../../types/services';
 
 const OPENAI_CHAT_PREFIXES = ['gpt-', 'o1', 'o3', 'o4', 'chatgpt-'];
@@ -65,7 +65,7 @@ export const callOpenAI = async (
   const data = await response.json();
 
   if (data?.choices?.[0]?.finish_reason === 'length') {
-    throw new Error('OpenAI response was truncated — the model ran out of output tokens. Please try again.');
+    throw new Error(TRUNCATED_RESPONSE_MESSAGE);
   }
 
   const text = data?.choices?.[0]?.message?.content;

--- a/src/services/bookmarks.ts
+++ b/src/services/bookmarks.ts
@@ -82,6 +82,18 @@ export const moveBookmark = async (
   });
 };
 
+export const removeBookmark = async (bookmarkId: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    chrome.bookmarks.remove(bookmarkId, () => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve();
+    });
+  });
+};
+
 export const createFolderPath = async (
   folderPath: string,
   pathToIdMap: FolderPathMap,

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -4,6 +4,7 @@ import { type FolderPathMap } from './bookmarks';
 export type OrganizeMessageType =
   | 'START_ORGANIZE'
   | 'GET_ORGANIZE_STATUS'
+  | 'ORGANIZE_PROGRESS'
   | 'ORGANIZE_COMPLETE'
   | 'ORGANIZE_ERROR';
 
@@ -20,6 +21,11 @@ export interface StartOrganizePayload {
   pathToIdMap: FolderPathMap;
   defaultParentId: string;
   maxOutputTokens?: number;
+}
+
+export interface OrganizeProgressPayload {
+  processedCount: number;
+  totalCount: number;
 }
 
 export interface OrganizeCompletePayload {

--- a/src/types/organize.ts
+++ b/src/types/organize.ts
@@ -46,6 +46,13 @@ export interface BulkOrganizeResult {
   assignments: BookmarkAssignment[];
 }
 
+// A set of bookmarks that share the same URL. The first is kept; the rest are
+// candidates for removal.
+export interface DuplicateGroup {
+  url: string;
+  bookmarks: CompactBookmark[];
+}
+
 export interface FolderTreeNode {
   name: string;
   path: string;

--- a/src/utils/duplicates.test.ts
+++ b/src/utils/duplicates.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeUrl,
+  findDuplicateBookmarks,
+  countRemovableDuplicates,
+  getDuplicateIdsToRemove,
+} from './duplicates';
+import { type CompactBookmark } from '../types/organize';
+
+const bm = (id: string, url: string, folder = 'Root'): CompactBookmark => ({
+  id,
+  url,
+  title: `title-${id}`,
+  currentFolderPath: folder,
+  currentFolderId: 'folder',
+});
+
+describe('normalizeUrl', () => {
+  it('strips a trailing slash', () => {
+    expect(normalizeUrl('https://example.com/page/')).toBe(normalizeUrl('https://example.com/page'));
+  });
+
+  it('lowercases the host but preserves path case', () => {
+    expect(normalizeUrl('https://EXAMPLE.com/Page')).toBe('https://example.com/Page');
+  });
+
+  it('keeps query strings distinct (?id=1 vs ?id=2)', () => {
+    expect(normalizeUrl('https://e.com/p?id=1')).not.toBe(normalizeUrl('https://e.com/p?id=2'));
+  });
+
+  it('handles non-URL strings without throwing', () => {
+    expect(normalizeUrl('  not a url/  ')).toBe('not a url');
+  });
+});
+
+describe('findDuplicateBookmarks', () => {
+  it('groups exact-duplicate URLs', () => {
+    const groups = findDuplicateBookmarks([
+      bm('1', 'https://a.com'),
+      bm('2', 'https://a.com'),
+      bm('3', 'https://b.com'),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].bookmarks.map(b => b.id)).toEqual(['1', '2']);
+  });
+
+  it('treats trailing slash and host case as the same', () => {
+    const groups = findDuplicateBookmarks([bm('1', 'https://A.com/x'), bm('2', 'https://a.com/x/')]);
+    expect(groups).toHaveLength(1);
+  });
+
+  it('ignores bookmarks with empty URLs', () => {
+    expect(findDuplicateBookmarks([bm('1', ''), bm('2', '')])).toHaveLength(0);
+  });
+
+  it('returns nothing when all URLs are unique', () => {
+    expect(findDuplicateBookmarks([bm('1', 'https://a.com'), bm('2', 'https://b.com')])).toHaveLength(0);
+  });
+});
+
+describe('countRemovableDuplicates / getDuplicateIdsToRemove', () => {
+  it('keeps the first of each group and removes the rest', () => {
+    const groups = findDuplicateBookmarks([
+      bm('1', 'https://a.com'),
+      bm('2', 'https://a.com'),
+      bm('3', 'https://a.com'),
+    ]);
+    expect(countRemovableDuplicates(groups)).toBe(2);
+    expect(getDuplicateIdsToRemove(groups)).toEqual(['2', '3']);
+  });
+
+  it('zero when there are no groups', () => {
+    expect(countRemovableDuplicates([])).toBe(0);
+    expect(getDuplicateIdsToRemove([])).toEqual([]);
+  });
+});

--- a/src/utils/duplicates.ts
+++ b/src/utils/duplicates.ts
@@ -1,0 +1,54 @@
+import { type CompactBookmark, type DuplicateGroup } from '../types/organize';
+
+// Normalizes a URL for exact-duplicate comparison: lowercases the scheme + host,
+// drops a trailing slash, and keeps the path/query/hash intact (so ?id=1 and
+// ?id=2 stay distinct).
+export const normalizeUrl = (url: string): string => {
+  const trimmed = url.trim();
+
+  try {
+    const parsed = new URL(trimmed);
+    const host = parsed.host.toLowerCase();
+    const path = parsed.pathname.length > 1 && parsed.pathname.endsWith('/')
+      ? parsed.pathname.slice(0, -1)
+      : parsed.pathname;
+    return `${parsed.protocol.toLowerCase()}//${host}${path}${parsed.search}${parsed.hash}`;
+  } catch {
+    // Not a parseable URL — fall back to a light normalization.
+    return trimmed.toLowerCase().replace(/\/+$/, '');
+  }
+};
+
+// Groups bookmarks that share the same normalized URL. Only groups with more
+// than one bookmark (i.e. actual duplicates) are returned.
+export const findDuplicateBookmarks = (bookmarks: CompactBookmark[]): DuplicateGroup[] => {
+  const bookmarksByUrl = new Map<string, CompactBookmark[]>();
+
+  for (const bookmark of bookmarks) {
+    if (!bookmark.url) continue;
+    const key = normalizeUrl(bookmark.url);
+    const existing = bookmarksByUrl.get(key);
+    if (existing) {
+      existing.push(bookmark);
+    } else {
+      bookmarksByUrl.set(key, [bookmark]);
+    }
+  }
+
+  const groups: DuplicateGroup[] = [];
+  for (const group of bookmarksByUrl.values()) {
+    if (group.length > 1) {
+      groups.push({ url: group[0].url, bookmarks: group });
+    }
+  }
+
+  return groups;
+};
+
+// Total number of bookmarks that would be removed (every copy except one per group).
+export const countRemovableDuplicates = (groups: DuplicateGroup[]): number =>
+  groups.reduce((total, group) => total + group.bookmarks.length - 1, 0);
+
+// IDs to remove: every copy except the first (kept) in each group.
+export const getDuplicateIdsToRemove = (groups: DuplicateGroup[]): string[] =>
+  groups.flatMap(group => group.bookmarks.slice(1).map(bookmark => bookmark.id));

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   chunkArray,
   getAiTimeoutMs,
@@ -8,6 +8,7 @@ import {
   createRetryableError,
   isRetryableError,
   formatElapsedTime,
+  fetchWithTimeout,
 } from './helpers';
 
 describe('chunkArray', () => {
@@ -43,7 +44,7 @@ describe('formatElapsedTime', () => {
 
 describe('humanizeApiError', () => {
   it('maps 429 to a rate-limit message', () => {
-    expect(humanizeApiError('whatever', 429)).toMatch(/rate limit/i);
+    expect(humanizeApiError('whatever', 429)).toMatch(/rate-limit/i);
   });
 
   it('maps 401 to an invalid-key message', () => {
@@ -104,5 +105,30 @@ describe('getAiTimeoutMs', () => {
     expect(getAiTimeoutMs(0)).toBe(60000);
     expect(getAiTimeoutMs(10)).toBe(65000);
     expect(getAiTimeoutMs(100000)).toBe(300000);
+  });
+});
+
+describe('fetchWithTimeout', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('converts a network failure into a friendly, retryable error (no raw "Failed to fetch")', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))));
+
+    try {
+      await fetchWithTimeout('https://example.test/api');
+      throw new Error('should have thrown');
+    } catch (error) {
+      expect((error as Error).message).not.toContain('Failed to fetch');
+      expect((error as Error).message).toMatch(/couldn't reach/i);
+      expect(isRetryableError(error)).toBe(true);
+    }
+  });
+
+  it('rejects when an external AbortSignal is supplied', async () => {
+    await expect(
+      fetchWithTimeout('https://example.test/api', { signal: new AbortController().signal })
+    ).rejects.toThrow(/AbortSignal/);
   });
 });

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  chunkArray,
+  getAiTimeoutMs,
+  hasArrayWithItems,
+  extractApiErrorMessage,
+  humanizeApiError,
+  createRetryableError,
+  isRetryableError,
+  formatElapsedTime,
+} from './helpers';
+
+describe('chunkArray', () => {
+  it('splits into chunks of the given size', () => {
+    expect(chunkArray([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('returns empty for an empty array', () => {
+    expect(chunkArray([], 3)).toEqual([]);
+  });
+
+  it('returns a single chunk when size exceeds length', () => {
+    expect(chunkArray([1, 2], 10)).toEqual([[1, 2]]);
+  });
+
+  it('guards against zero or negative size', () => {
+    expect(chunkArray([1, 2, 3], 0)).toEqual([[1], [2], [3]]);
+  });
+});
+
+describe('formatElapsedTime', () => {
+  it('formats as m:ss', () => {
+    expect(formatElapsedTime(0)).toBe('0:00');
+    expect(formatElapsedTime(5)).toBe('0:05');
+    expect(formatElapsedTime(75)).toBe('1:15');
+    expect(formatElapsedTime(600)).toBe('10:00');
+  });
+
+  it('clamps negative input', () => {
+    expect(formatElapsedTime(-5)).toBe('0:00');
+  });
+});
+
+describe('humanizeApiError', () => {
+  it('maps 429 to a rate-limit message', () => {
+    expect(humanizeApiError('whatever', 429)).toMatch(/rate limit/i);
+  });
+
+  it('maps 401 to an invalid-key message', () => {
+    expect(humanizeApiError('x', 401)).toMatch(/api key/i);
+  });
+
+  it('maps 5xx to unavailable', () => {
+    expect(humanizeApiError('x', 503)).toMatch(/unavailable/i);
+  });
+
+  it('never leaks raw API text or status code on unknown errors', () => {
+    const raw = 'INTERNAL_TRACE: secret stack at 0xdeadbeef';
+    const out = humanizeApiError(raw, 418);
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('418');
+  });
+});
+
+describe('isRetryableError', () => {
+  it('flags errors created as retryable', () => {
+    expect(isRetryableError(createRetryableError('x'))).toBe(true);
+  });
+
+  it('does not flag plain errors', () => {
+    expect(isRetryableError(new Error('x'))).toBe(false);
+  });
+
+  it('does not flag non-errors', () => {
+    expect(isRetryableError(null)).toBe(false);
+    expect(isRetryableError(undefined)).toBe(false);
+  });
+});
+
+describe('extractApiErrorMessage', () => {
+  it('pulls error.message from a JSON body', () => {
+    expect(extractApiErrorMessage('{"error":{"message":"boom"}}')).toBe('boom');
+  });
+
+  it('returns null for non-JSON bodies', () => {
+    expect(extractApiErrorMessage('not json')).toBeNull();
+  });
+});
+
+describe('hasArrayWithItems', () => {
+  it('true for a non-empty array property', () => {
+    expect(hasArrayWithItems({ items: [1] }, 'items')).toBe(true);
+  });
+
+  it('false for empty, missing, or non-object', () => {
+    expect(hasArrayWithItems({ items: [] }, 'items')).toBe(false);
+    expect(hasArrayWithItems({}, 'items')).toBe(false);
+    expect(hasArrayWithItems(null, 'items')).toBe(false);
+  });
+});
+
+describe('getAiTimeoutMs', () => {
+  it('scales with bookmark count and caps at the ceiling', () => {
+    expect(getAiTimeoutMs(0)).toBe(60000);
+    expect(getAiTimeoutMs(10)).toBe(65000);
+    expect(getAiTimeoutMs(100000)).toBe(300000);
+  });
+});

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -9,6 +9,21 @@ export const getAiTimeoutMs = (bookmarkCount: number = 1): number => {
   );
 };
 
+// Errors flagged retryable are transient (overload, rate limit, timeout) and
+// worth retrying with backoff — important for free tiers that 503 under load.
+export interface RetryableError extends Error {
+  retryable?: boolean;
+}
+
+export const createRetryableError = (message: string): RetryableError => {
+  const error: RetryableError = new Error(message);
+  error.retryable = true;
+  return error;
+};
+
+export const isRetryableError = (error: unknown): boolean =>
+  Boolean((error as RetryableError)?.retryable);
+
 export const fetchWithTimeout = async (
   url: string,
   options: RequestInit = {},
@@ -25,12 +40,30 @@ export const fetchWithTimeout = async (
     return await fetch(url, { ...options, signal: controller.signal });
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new Error('Request timed out. Please try again.');
+      throw createRetryableError('Request timed out. Please try again.');
     }
     throw error;
   } finally {
     clearTimeout(timeoutId);
   }
+};
+
+// Formats elapsed seconds as m:ss (e.g. 75 -> "1:15") for the organizing timer.
+export const formatElapsedTime = (totalSeconds: number): string => {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+// Splits an array into chunks of at most chunkSize items (last chunk may be smaller).
+export const chunkArray = <T>(items: T[], chunkSize: number): T[][] => {
+  const safeSize = Math.max(1, Math.floor(chunkSize));
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += safeSize) {
+    chunks.push(items.slice(index, index + safeSize));
+  }
+  return chunks;
 };
 
 export const hasArrayWithItems = (data: unknown, propertyName: string): boolean => {
@@ -65,11 +98,20 @@ export const extractApiErrorMessage = (responseBody: string): string | null => {
   }
 };
 
+// Shown when the model's reply is cut off — kept jargon-free (no "tokens").
+export const TRUNCATED_RESPONSE_MESSAGE =
+  'The AI response was cut off. Try selecting fewer bookmarks, or choose a model with a larger response limit.';
+
 export const throwApiResponseError = async (providerName: string, response: Response): Promise<never> => {
   const errorBody = await response.text();
   console.error(`${providerName} API error [${response.status}]:`, errorBody);
   const rawMessage = extractApiErrorMessage(errorBody);
-  throw new Error(humanizeApiError(rawMessage || `${providerName} error: ${response.status}`, response.status));
+  const error: RetryableError = new Error(
+    humanizeApiError(rawMessage || `${providerName} error: ${response.status}`, response.status)
+  );
+  // 429 (rate limit) and 5xx (overload/unavailable) are transient — safe to retry.
+  error.retryable = response.status === 429 || response.status >= 500;
+  throw error;
 };
 
 export const humanizeApiError = (rawMessage: string, statusCode: number): string => {
@@ -95,9 +137,11 @@ export const humanizeApiError = (rawMessage: string, statusCode: number): string
     return 'AI service temporarily unavailable. Please try again later.';
   }
 
-  if (rawMessage.length > 120) {
-    return rawMessage.slice(0, 117) + '...';
+  if (statusCode === 400) {
+    return "The AI couldn't handle this request. Try a different model or fewer bookmarks.";
   }
 
-  return rawMessage;
+  // Unknown error — keep it friendly. Never expose raw API text or status codes;
+  // the real detail is already logged to the console for developers.
+  return 'Something went wrong with the AI service. Please try again, or choose a different model.';
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -42,6 +42,13 @@ export const fetchWithTimeout = async (
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw createRetryableError('Request timed out. Please try again.');
     }
+    // A network-level failure (offline, DNS, or the AI endpoint refusing the
+    // connection) surfaces as a TypeError "Failed to fetch" — make it readable.
+    if (error instanceof TypeError) {
+      throw createRetryableError(
+        "Couldn't reach the AI service. Check your internet connection and try again. If it keeps failing, the model may be overloaded — try a more reliable model or provider."
+      );
+    }
     throw error;
   } finally {
     clearTimeout(timeoutId);
@@ -118,7 +125,7 @@ export const humanizeApiError = (rawMessage: string, statusCode: number): string
   const lower = rawMessage.toLowerCase();
 
   if (statusCode === 429 || lower.includes('quota') || lower.includes('rate limit')) {
-    return 'Rate limit reached. Wait a moment or try a different model.';
+    return 'The AI service is rate-limiting requests. Free and smaller models hit these limits quickly — wait a moment, or switch to a more capable model or a paid API key for large batches.';
   }
 
   if (statusCode === 401 || lower.includes('unauthorized') || lower.includes('invalid api key') || lower.includes('incorrect api key')) {
@@ -134,7 +141,7 @@ export const humanizeApiError = (rawMessage: string, statusCode: number): string
   }
 
   if (statusCode >= 500) {
-    return 'AI service temporarily unavailable. Please try again later.';
+    return 'The AI service is overloaded right now. Free and smaller models (like free Gemini) are often unavailable under load — try again shortly, or switch to a more reliable model or provider.';
   }
 
   if (statusCode === 400) {

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -28,6 +28,13 @@ describe('escapeControlCharsInJsonStrings', () => {
     const ok = '{"a": "she said \\"hi\\""}';
     expect(JSON.parse(escapeControlCharsInJsonStrings(ok)).a).toBe('she said "hi"');
   });
+
+  it('escapes a control char that directly follows a backslash', () => {
+    // Backslash immediately followed by a literal newline (0x0A).
+    const bad = '{"a": "path\\\nmore"}';
+    const fixed = escapeControlCharsInJsonStrings(bad);
+    expect(() => JSON.parse(fixed)).not.toThrow();
+  });
 });
 
 describe('parseJsonLoose', () => {

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { escapeControlCharsInJsonStrings, parseJsonLoose } from './json';
+
+describe('escapeControlCharsInJsonStrings', () => {
+  it('escapes literal newlines inside string values (the real bug)', () => {
+    const bad = '{"summary": "line one\nline two"}';
+    const fixed = escapeControlCharsInJsonStrings(bad);
+    expect(() => JSON.parse(fixed)).not.toThrow();
+    expect(JSON.parse(fixed).summary).toBe('line one\nline two');
+  });
+
+  it('escapes tabs and carriage returns inside strings', () => {
+    const bad = '{"a": "x\ty\rz"}';
+    expect(JSON.parse(escapeControlCharsInJsonStrings(bad)).a).toBe('x\ty\rz');
+  });
+
+  it('leaves structural whitespace between tokens untouched', () => {
+    const ok = '{\n  "a": 1\n}';
+    expect(JSON.parse(escapeControlCharsInJsonStrings(ok))).toEqual({ a: 1 });
+  });
+
+  it('does not double-escape already-escaped sequences', () => {
+    const ok = '{"a": "line\\nbreak"}';
+    expect(JSON.parse(escapeControlCharsInJsonStrings(ok)).a).toBe('line\nbreak');
+  });
+
+  it('handles escaped quotes inside a string', () => {
+    const ok = '{"a": "she said \\"hi\\""}';
+    expect(JSON.parse(escapeControlCharsInJsonStrings(ok)).a).toBe('she said "hi"');
+  });
+});
+
+describe('parseJsonLoose', () => {
+  it('parses valid JSON normally', () => {
+    expect(parseJsonLoose('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('recovers JSON with literal newlines in string values', () => {
+    const bad = '{"summary": "a\nb", "n": 2}';
+    expect(parseJsonLoose(bad)).toEqual({ summary: 'a\nb', n: 2 });
+  });
+
+  it('throws on truly invalid JSON', () => {
+    expect(() => parseJsonLoose('{not json')).toThrow();
+  });
+});

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,58 @@
+// AI models sometimes emit raw control characters (literal newlines, tabs, etc.)
+// inside JSON string values — for example a multi-line "summary". Those break
+// JSON.parse with "Bad control character in string literal". This walks the text
+// and escapes any control characters that appear INSIDE string literals, leaving
+// structural whitespace untouched.
+export const escapeControlCharsInJsonStrings = (json: string): string => {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < json.length; index += 1) {
+    const char = json[index];
+
+    // Previous char was a backslash — keep this char as-is (it's an escape sequence).
+    if (escaped) {
+      result += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      result += char;
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      result += char;
+      continue;
+    }
+
+    if (inString) {
+      const code = char.charCodeAt(0);
+      if (code < 0x20) {
+        if (char === '\n') result += '\\n';
+        else if (char === '\r') result += '\\r';
+        else if (char === '\t') result += '\\t';
+        else result += `\\u${code.toString(16).padStart(4, '0')}`;
+        continue;
+      }
+    }
+
+    result += char;
+  }
+
+  return result;
+};
+
+// Parses JSON, retrying with control characters escaped if the first attempt
+// fails — tolerant of the malformed-but-recoverable JSON models often produce.
+export const parseJsonLoose = (jsonText: string): unknown => {
+  try {
+    return JSON.parse(jsonText);
+  } catch {
+    return JSON.parse(escapeControlCharsInJsonStrings(jsonText));
+  }
+};

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -11,8 +11,22 @@ export const escapeControlCharsInJsonStrings = (json: string): string => {
   for (let index = 0; index < json.length; index += 1) {
     const char = json[index];
 
-    // Previous char was a backslash — keep this char as-is (it's an escape sequence).
+    // Previous char was a backslash. A real escape sequence is kept as-is, but a
+    // literal control char here (e.g. backslash directly followed by a newline)
+    // is still invalid JSON — emit the escape letter so the existing backslash
+    // forms a valid sequence (\ + newline -> \n).
     if (escaped) {
+      if (inString) {
+        const code = char.charCodeAt(0);
+        if (code < 0x20) {
+          if (char === '\n') result += 'n';
+          else if (char === '\r') result += 'r';
+          else if (char === '\t') result += 't';
+          else result += `u${code.toString(16).padStart(4, '0')}`;
+          escaped = false;
+          continue;
+        }
+      }
       result += char;
       escaped = false;
       continue;

--- a/src/utils/loadingMessages.test.ts
+++ b/src/utils/loadingMessages.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buildLoadingMessage, getNextLoadingMessageIndex } from './loadingMessages';
+import { LOADING_MESSAGE_TEMPLATES } from '../config/loadingMessages';
+
+const countTemplateIndex = LOADING_MESSAGE_TEMPLATES.findIndex(template =>
+  template.includes('{bookmarks}')
+);
+
+describe('buildLoadingMessage', () => {
+  it('substitutes a formatted, pluralized bookmark count', () => {
+    const message = buildLoadingMessage(countTemplateIndex, 1240);
+    expect(message).toContain('1,240 bookmarks');
+    expect(message).not.toContain('{bookmarks}');
+  });
+
+  it('uses the singular form for one bookmark', () => {
+    const message = buildLoadingMessage(countTemplateIndex, 1);
+    expect(message).toContain('1 bookmark');
+    expect(message).not.toContain('1 bookmarks');
+  });
+
+  it('wraps an out-of-range index instead of throwing', () => {
+    expect(() => buildLoadingMessage(999, 5)).not.toThrow();
+  });
+});
+
+describe('getNextLoadingMessageIndex', () => {
+  it('wraps back to zero at the end', () => {
+    expect(getNextLoadingMessageIndex(LOADING_MESSAGE_TEMPLATES.length - 1)).toBe(0);
+  });
+
+  it('advances by one otherwise', () => {
+    expect(getNextLoadingMessageIndex(0)).toBe(1);
+  });
+});

--- a/src/utils/loadingMessages.ts
+++ b/src/utils/loadingMessages.ts
@@ -1,0 +1,18 @@
+import { LOADING_MESSAGE_TEMPLATES } from '../config/loadingMessages';
+
+// Builds a status message from a template, substituting the real bookmark count
+// so the user sees what is actually happening (no fake progress).
+
+const formatBookmarkCount = (bookmarkCount: number): string => {
+  const formatted = bookmarkCount.toLocaleString();
+  return `${formatted} bookmark${bookmarkCount === 1 ? '' : 's'}`;
+};
+
+export const buildLoadingMessage = (index: number, bookmarkCount: number): string => {
+  const template = LOADING_MESSAGE_TEMPLATES[index % LOADING_MESSAGE_TEMPLATES.length];
+  return template.replace(/\{bookmarks\}/g, formatBookmarkCount(bookmarkCount));
+};
+
+export const getNextLoadingMessageIndex = (currentIndex: number): number => {
+  return (currentIndex + 1) % LOADING_MESSAGE_TEMPLATES.length;
+};

--- a/src/utils/scale.test.ts
+++ b/src/utils/scale.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { chunkArray } from './helpers';
+import { findDuplicateBookmarks, countRemovableDuplicates } from './duplicates';
+import { computeBatchSize } from '../services/ai/bulkOrganize';
+import { type CompactBookmark } from '../types/organize';
+
+// Simulates a heavy user's library at scale. These cover the pure logic only
+// (no API calls) — they prove batching math and dedupe stay correct and fast
+// for 5k–10k bookmarks.
+
+const makeBookmarks = (count: number, urlFactory: (index: number) => string): CompactBookmark[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: String(index),
+    url: urlFactory(index),
+    title: `bookmark ${index}`,
+    currentFolderPath: 'Root',
+    currentFolderId: 'folder',
+  }));
+
+describe('scale: batching math', () => {
+  it('chunks 10,000 bookmarks into the expected number of batches', () => {
+    const batchSize = computeBatchSize(1_000_000); // huge model -> 150 cap
+    expect(batchSize).toBe(150);
+
+    const bookmarks = makeBookmarks(10_000, i => `https://site.com/page${i}`);
+    const batches = chunkArray(bookmarks, batchSize);
+
+    expect(batches).toHaveLength(Math.ceil(10_000 / 150)); // 67
+    expect(batches.flat()).toHaveLength(10_000); // nothing dropped
+    expect(batches[batches.length - 1]).toHaveLength(10_000 - 66 * 150); // 100
+  });
+
+  it('a small/free model produces more, smaller batches for 5,000 bookmarks', () => {
+    const batchSize = computeBatchSize(4096); // -> 35
+    expect(batchSize).toBe(35);
+
+    const batches = chunkArray(makeBookmarks(5_000, i => `https://site.com/p${i}`), batchSize);
+    expect(batches).toHaveLength(Math.ceil(5_000 / 35)); // 143
+    expect(batches.flat()).toHaveLength(5_000);
+  });
+});
+
+describe('scale: duplicate detection', () => {
+  it('finds every duplicate in a 10,000-bookmark library', () => {
+    // Each URL appears exactly twice -> 5,000 groups, 5,000 removable.
+    const bookmarks = makeBookmarks(10_000, i => `https://site.com/page${i % 5_000}`);
+    const groups = findDuplicateBookmarks(bookmarks);
+
+    expect(groups).toHaveLength(5_000);
+    expect(countRemovableDuplicates(groups)).toBe(5_000);
+  });
+
+  it('handles a 10,000-bookmark library with no duplicates', () => {
+    const bookmarks = makeBookmarks(10_000, i => `https://site.com/unique${i}`);
+    expect(findDuplicateBookmarks(bookmarks)).toHaveLength(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Standalone config (does not load the crx Vite plugin) — logic-only unit tests
+// run in a plain Node environment, no browser or Chrome APIs needed.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Closes #43

## Why

Triggered by a Chrome Web Store review: a user set up a free Gemini key, ran organize, saw "MarkMind keeps organizing in the background," but couldn't tell if it was working — and her bookmarks looked unchanged. Investigation found several real gaps: no honest progress, large collections silently failing on small/free models, technical error messages, and no duplicate handling.

## What changed

### Reliability — organize now works on large libraries and free tiers
- **Adaptive batching**: bookmarks are organized in sequential passes, each sized to the selected model's output-token budget (clamped 25–150). The accumulating folder plan is fed into each next pass so folders stay coherent across batches (no "Dev" + "Development" fragmentation). Scales to thousands of bookmarks on any model, including free tiers.
- **Retry with backoff**: transient failures (503 / 429 / timeout) are retried with exponential backoff. Free-tier models that briefly 503 under load now succeed instead of failing instantly.
- **Partial results**: if a later pass fails, completed work is kept and the user is told to run again to finish the rest — nothing is discarded.
- **Tolerant JSON parsing**: models sometimes emit raw control characters (e.g. a multi-line `summary`) inside JSON string values, which broke `JSON.parse`. We now escape control chars inside string literals before parsing. This was a real bug that failed 168 of 203 bookmarks in testing.

### Transparency — you can tell it's working
- Live **"Organized N of M bookmarks"** count plus an **elapsed timer** that survives closing/reopening the popup (`ORGANIZE_PROGRESS` message from the service worker).
- Status/error messages are **provider-agnostic and jargon-free** — no status codes, no raw API text. Real diagnostics still go to `console.error` for developers; response bodies are no longer logged (avoids leaking user bookmark data).

### Duplicate cleanup (new)
- Exact-URL duplicate detection (normalizes trailing slash + host case).
- Review panel listing each duplicate group (keep one, remove the rest) with a **two-step confirm** before any permanent deletion.

### UX
- Plain-language heads-up before organizing very large selections.

### Docs
- README documents loose-bookmark handling, timeframe expectations, and free-tier behaviour (answers the reviewer's questions directly).

## Tests
- Added **Vitest** with a 49-test suite (`npm test`, ~150ms, no browser/API):
  - Tolerant JSON parsing (incl. a regression test for the 168-fail bug)
  - Duplicate detection / URL normalization
  - Adaptive batch sizing, chunking, friendly errors, retry flags, elapsed formatting
  - 5k / 10k-scale behaviour (correct batch counts, nothing dropped, dedupe correctness)

## Verification
- `npm test` — 49 passing
- `tsc --noEmit` — clean
- `eslint src/` — clean
- `vite build` — clean
- Manual: end-to-end organize of 203 bookmarks on OpenRouter and free Gemini, duplicate review + delete, progress timer across popup reopen, large-collection note.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
